### PR TITLE
Configurando smart cache para lambda functions 

### DIFF
--- a/pages/api/cep/[cep].js
+++ b/pages/api/cep/[cep].js
@@ -3,6 +3,8 @@ import cep from 'cep-promise';
 export default async function Cep(request, response) {
     const requestedCep = request.query.cep;
 
+    response.setHeader('Cache-Control', 'max-age=0, s-maxage=86400');
+
     try {
         const cepResult = await cep(requestedCep);
 


### PR DESCRIPTION
# Descrição

Esse PR altera os headers da resposta da API para passar fazer o cache das respostas das lambdas.

Tomei como base a doc contida em https://zeit.co/docs/v2/serverless-functions/edge-caching

Usando a configuração recomendada:
<img width="754" alt="Screen Shot 2020-01-30 at 21 23 49" src="https://user-images.githubusercontent.com/8251208/73502220-01fa4600-43a7-11ea-8456-2078355901db.png">

Os testes da alteração serão postadas como comentários no PR.

Relates to issue https://github.com/filipedeschamps/BrasilAPI/issues/6