### PR TITLE
feat: cache control como decorador

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import cors from 'cors';
 import onError from './middlewares/errorHandler';
 import cache from './middlewares/cache';
 import logger from './middlewares/logger';
+import { cacheExpires } from './middlewares/constants';
 
 const corsDefaultConfiguration = {
   origin: '*',
@@ -11,8 +12,6 @@ const corsDefaultConfiguration = {
   preflightContinue: false,
   optionsSuccessStatus: 204,
 };
-
-const cacheDefaultConfiguration = 86400;
 
 const onNoMatch = (request, response) => {
   return response.status(404).json({
@@ -24,7 +23,7 @@ const onNoMatch = (request, response) => {
 
 export default (options = {}) => {
   const corsOptions = options.cors || {};
-  const cacheOptions = options.cache || cacheDefaultConfiguration;
+  const cacheOptions = options.cache || cacheExpires;
 
   const configurations = {
     cors: {

--- a/graphql/decorators/cache.js
+++ b/graphql/decorators/cache.js
@@ -1,0 +1,29 @@
+// max-age especifica quanto tempo o browser deve manter o valor em cache, em segundos.
+// s-maxage é uma header lida pelo servidor proxy (neste caso, Vercel).
+// stale-while-revalidate indica que o conteúdo da cache pode ser servido como "stale" e revalidado no background
+//
+// Por que os valores abaixo?
+//
+// 1. O cache da Now é muito rápido e permite respostas em cerca de 10ms. O valor de
+//    um dia (86400 segundos) é suficiente para garantir performance e também que as
+//    respostas estejam relativamente sincronizadas caso o governo decida atualizar os CEPs.
+// 2. O cache da Now é invalidado toda vez que um novo deploy é feito, garantindo que
+//    todas as novas requisições sejam servidas pela implementação mais recente da API.
+// 3. Não há browser caching pois este tipo de API normalmente é utilizada uma vez só
+//    por um usuário. Se fizessemos caching, os valores ficariam lá guardados no browser
+//    sem necessidade, só ocupando espaço em disco. A história seria diferente se a API
+//    servisse fotos dos usuários, por exemplo. Além disso teríamos problemas com
+//    stale/out-of-date cache caso alterássemos a implementação da API.
+
+export default {
+  of: (time) => {
+    const CACHE_CONTROL_HEADER_VALUE = `max-age=0, s-maxage=${time}, stale-while-revalidate, public`;
+    return (resolver) => {
+      return async (_parent, _args, _context) => {
+        const next = () => resolver(_parent, _args, _context);
+        _context.res.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
+        return next();
+      };
+    };
+  },
+};

--- a/graphql/modules/cep/resolvers.js
+++ b/graphql/modules/cep/resolvers.js
@@ -1,35 +1,16 @@
 import { ApolloError } from 'apollo-server-micro';
 import cep from 'cep-promise';
 
-// max-age especifica quanto tempo o browser deve manter o valor em cache, em segundos.
-// s-maxage é uma header lida pelo servidor proxy (neste caso, Vercel).
-// stale-while-revalidate indica que o conteúdo da cache pode ser servido como "stale" e revalidado no background
-//
-// Por que os valores abaixo?
-//
-// 1. O cache da Now é muito rápido e permite respostas em cerca de 10ms. O valor de
-//    um dia (86400 segundos) é suficiente para garantir performance e também que as
-//    respostas estejam relativamente sincronizadas caso o governo decida atualizar os CEPs.
-// 2. O cache da Now é invalidado toda vez que um novo deploy é feito, garantindo que
-//    todas as novas requisições sejam servidas pela implementação mais recente da API.
-// 3. Não há browser caching pois este tipo de API normalmente é utilizada uma vez só
-//    por um usuário. Se fizessemos caching, os valores ficariam lá guardados no browser
-//    sem necessidade, só ocupando espaço em disco. A história seria diferente se a API
-//    servisse fotos dos usuários, por exemplo. Além disso teríamos problemas com
-//    stale/out-of-date cache caso alterássemos a implementação da API.
-const CACHE_CONTROL_HEADER_VALUE =
-  'max-age=0, s-maxage=86400, stale-while-revalidate, public';
-
 export default {
   Query: {
-    cep: async (_parent, _args, _context) => {
+    cep: async (_parent, _args) => {
       if (_args.cep.length !== 8) {
         throw new ApolloError('CEP inválido', 'validation_error');
       }
 
       try {
-        _context.res.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
-        return await cep(_args.cep);
+        const cepResult = await cep(_args.cep);
+        return cepResult;
       } catch (err) {
         throw new ApolloError('Erro ao consultar CEP', err.type, err.errors);
       }

--- a/middlewares/constants.js
+++ b/middlewares/constants.js
@@ -1,0 +1,1 @@
+export const cacheExpires = 86400;


### PR DESCRIPTION
Olá pessoal, nos últimos dias eu estava olhando o repositório e tentando ajudar com revisões. Notei em uma das revisões que a utilização de decoradores para envelopes poderia ajudar bastante removendo a parte o que não pertence ao domínio. (Vide PR para rate-limit: https://github.com/filipedeschamps/BrasilAPI/pull/113)

Percebi que o cache control também poderia ser abstraído. Vocês acham interessante? Vale a pena?

### Glossário

**Envelope**: estou me referindo ao http handler e graphql resolver.

### Sugestão


Notei dentre as revisões o comentário de unificar error. Com a adição de decoradores de envelopes podemos fazer o tratamento de erro a parte tbm criando custom Errors.

```
// src: errors/ValidationModel.js

export default class ValidationModel extends Error {
  constructor (message, detail) {
    super(message)

    this.statusCode = 400;
    this.name = this.constructor.name
    // detail não precisa ser string, poderia ser um objeto com estrutura definida (por exemplo, coleção de validações).
    // poderia ser chamado do que quisermos tbm
    this.detail = detail;
  }
}
```

E o decorador de tratamento de erros converteria na resposta adequada dependendo do envelope.