### PR TITLE
fix: update repository URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Qualquer ajuda que agregue valor ao projeto, seja na edição do código-fonte o
 - Crie uma branch com a sua feature: `git checkout -b my-feature`
 - Commit suas mudanças: `git commit -m 'feat: My new feature'`
 - Push a sua branch: `git push origin my-feature`
-- Ir em [Pull Requests](https://github.com/filipedeschamps/BrasilAPI/pulls) do projeto original e criar uma pull request com o seu commit
+- Ir em [Pull Requests](https://github.com/BrasilAPI/BrasilAPI/pulls) do projeto original e criar uma pull request com o seu commit
 
 ### Manter o fork atualizado:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </div>
 
 <div align="center">
-  <img src="https://github.com/filipedeschamps/BrasilAPI/workflows/Testes%20E2E/badge.svg">
+  <img src="https://github.com/BrasilAPI/BrasilAPI/workflows/Testes%20E2E/badge.svg">
 </div>
 
 ## Motivo

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/filipedeschamps/BrasilAPI.git"
+    "url": "git+https://github.com/BrasilAPI/BrasilAPI.git"
   },
   "author": "Filipe Deschamps",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/filipedeschamps/BrasilAPI/issues"
   },
-  "homepage": "https://github.com/filipedeschamps/BrasilAPI#readme"
+  "homepage": "https://github.com/BrasilAPI/BrasilAPI#readme"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "Filipe Deschamps",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/filipedeschamps/BrasilAPI/issues"
+    "url": "https://github.com/BrasilAPI/BrasilAPI/issues"
   },
   "homepage": "https://github.com/BrasilAPI/BrasilAPI#readme"
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ export default function Index() {
       <div>
         <a
           className="logo"
-          href="https://github.com/filipedeschamps/BrasilAPI"
+          href="https://github.com/BrasilAPI/BrasilAPI"
           alt="Acessar repositório do BrasilAPI no Github"
         >
           <img src="/brasilapi-logo-medium.png" />


### PR DESCRIPTION
This PR changes the links for the repository URL from [filipedeschamps/brasilAPI](http://github.com/filipedeschamps/brasilAPI) to link to the organization [brazilAPI/brazilAPI](https://github.com/BrasilAPI/BrasilAPI) on everyplace it's being linked.