### PR TITLE
feat: endpoint para retornar todos os feriados brasileiros pelo ano.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "apollo-server-micro": "^2.11.0",
     "axios": "0.19.2",
+    "brazilian-holidays": "^1.0.2",
     "cep-promise": "3.0.9",
     "cidades-promise": "^1.2.3",
     "lodash": "^4.17.19",

--- a/pages/api/holiday/v1/[year].js
+++ b/pages/api/holiday/v1/[year].js
@@ -1,0 +1,27 @@
+import { getBrazilianHolidays } from 'brazilian-holidays';
+import microCors from 'micro-cors';
+
+const CACHE_CONTROL_HEADER_VALUE =
+  'max-age=0, s-maxage=86400, stale-while-revalidate';
+const cors = microCors();
+
+// retorna feriados brasileiros pelo ano
+// exemplo da rota: /api/cities/v1/ddd/21
+
+async function HolidaysByYear(request, response) {
+  const { year } = request.query;
+
+  response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
+
+  try {
+    const holidays = await getBrazilianHolidays(year);
+
+    response.status(200);
+    response.json(holidays);
+  } catch (error) {
+    response.status(500);
+    response.json(error);
+  }
+}
+
+export default cors(HolidaysByYear);

--- a/tests/helpers/scenarios/holiday/incorrect.json
+++ b/tests/helpers/scenarios/holiday/incorrect.json
@@ -1,0 +1,4 @@
+{
+  "error": "Year out of range",
+  "message": "Specify a year between 2000 and the current year"
+}

--- a/tests/helpers/scenarios/holiday/success.json
+++ b/tests/helpers/scenarios/holiday/success.json
@@ -1,0 +1,56 @@
+[
+  {
+    "month": "Janeiro",
+    "month_day": 1,
+    "week_day": "qua",
+    "holiday": "Dia da Confraternização Universal"
+  },
+  {
+    "month": "Abril",
+    "month_day": 10,
+    "week_day": "sex",
+    "holiday": "Sexta-feira Santa"
+  },
+  {
+    "month": "Abril",
+    "month_day": 21,
+    "week_day": "ter",
+    "holiday": "Tiradentes"
+  },
+  {
+    "month": "Maio",
+    "month_day": 1,
+    "week_day": "sex",
+    "holiday": "Dia do Trabalho"
+  },
+  {
+    "month": "Setembro",
+    "month_day": 7,
+    "week_day": "seg",
+    "holiday": "Dia da Independência do Brasil - 7 de Setembro"
+  },
+  {
+    "month": "Outubro",
+    "month_day": 12,
+    "week_day": "seg",
+    "holiday": "Nossa Senhora Aparecida"
+  },
+  {
+    "month": "Novembro",
+    "month_day": 2,
+    "week_day": "seg",
+    "holiday": "Finados"
+  },
+  {
+    "month": "Novembro",
+    "month_day": 15,
+    "week_day": "dom",
+    "holiday": "Proclamação da República"
+  },
+  {
+    "month": "Dezembro",
+    "month_day": 25,
+    "week_day": "sex",
+    "holiday": "Natal"
+  }
+]

--- a/tests/holiday-v1.test.js
+++ b/tests/holiday-v1.test.js
@@ -26,7 +26,6 @@ describe('api/holiday/2020 (E2E)', () => {
   });
 
   test('Utilizando um ano inválido: 1900', async () => {
-    expect.assertions(2);
     const requestUrl = `${server.getUrl()}/api/holiday/v1/1900`;
 
     try {

--- a/tests/holiday-v1.test.js
+++ b/tests/holiday-v1.test.js
@@ -1,0 +1,41 @@
+const axios = require('axios');
+
+const createServer = require('./helpers/server.js');
+
+const server = createServer();
+
+beforeAll(async () => {
+  await server.start();
+});
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const scenariosHoliday = {
+  success: require('./helpers/scenarios/holiday/success'),
+  incorrect: require('./helpers/scenarios/holiday/incorrect'),
+};
+
+describe('api/holiday/2020 (E2E)', () => {
+  test('Utilizando um ano válido: 2020', async () => {
+    const requestUrl = `${server.getUrl()}/api/holiday/v1/2020`;
+    const response = await axios.get(requestUrl);
+
+    expect(response.data).toEqual(scenariosHoliday.success);
+  });
+
+  test('Utilizando um ano inválido: 1900', async () => {
+    expect.assertions(2);
+    const requestUrl = `${server.getUrl()}/api/holiday/v1/1900`;
+
+    try {
+      await axios.get(requestUrl);
+    } catch (error) {
+      const { response } = error;
+
+      expect(response.status).toBe(500);
+      expect(response.data).toMatchObject(scenariosHoliday.incorrect);
+    }
+  });
+});


### PR DESCRIPTION
A consulta é feita no site https://www.calendarr.com/brasil/feriados-2020/

**Não é necessário token, os resultados são coletados através da raspagem.**


Exemplo do endpoint:
```
/api/holiday/v1/2020
````

Os dados são retornados no formato:

```
[
   {
       month: 'Janeiro',
       month_day: 28,
       week_day: 'sex',
       holiday: 'Nome do feriado'
   } 
]
```
