### PR TITLE
Correção do fluxo de testes e CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,46 +1,13 @@
 name: Testes E2E
 
-on: [deployment_status]
+on: [pull_request]
 
 jobs:
-  mark-commit-status-pending:
-    name: Marcar "status" do commit como "pending"
-    if: github.event.deployment_status.state == 'pending'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Fazer request contra API do Github com status "pending"
-        run: |
-          curl -L -X POST \
-          --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'content-type: application/json' \
-          --data '{
-            "state": "pending",
-            "context": "e2e-tests",
-            "description": "Aguardando a Preview URL da Vercel"
-            }'
-      
   e2e-tests:
-    name: Rodar testes E2E contra a Preview URL da Vercel
-    if: github.event.deployment_status.state == 'success'
+    name: Rodar testes E2E
     runs-on: ubuntu-latest
 
     steps:
-      - name: Atualizar o status "pending" com o "Workflow URL"
-        run: |
-          GITHUB_WORKFLOW_URL=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-          curl -L -X POST \
-          --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'content-type: application/json' \
-          --data '{
-            "state": "pending",
-            "context": "e2e-tests",
-            "description": "Realizando testes E2E contra a Preview URL",
-            "target_url": "'${GITHUB_WORKFLOW_URL}'"
-            }'
-
       - name: Puxar o código do commit
         uses: actions/checkout@v2
 
@@ -52,26 +19,5 @@ jobs:
       - name: Instalar as dependências do npm
         run: npm install
 
-      - name: Rodar testes utilizando a Preview URL da Vercel
+      - name: Rodar testes
         run: npm test
-        env:
-          NODE_ENV: 'ci'
-          PREVIEW_URL: ${{ github.event.deployment_status.target_url }}
-
-      - name: Fazer request contra API do Github status final
-        if: always()
-        env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-        run: |
-          GITHUB_WORKFLOW_URL=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-          JOB_STATUS=$(echo ${JOB_CONTEXT} | jq --raw-output '.status | ascii_downcase')
-          curl -L -X POST \
-          --url https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'content-type: application/json' \
-          --data '{
-            "state": "'${JOB_STATUS}'",
-            "context": "e2e-tests",
-            "description": "Finalizados os testes E2E contra a Preview URL.",
-            "target_url": "'${GITHUB_WORKFLOW_URL}'"
-            }'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   testTimeout: 30000,
+  globals: {
+    SERVER_URL: 'http://localhost:3000',
+  },
+  globalSetup: './tests/helpers/server/setup',
+  globalTeardown: './tests/helpers/server/teardown',
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "test": "jest",
+    "test": "jest --forceExit",
     "test:watch": "jest --watch",
     "fix": "eslint . --ext .js --fix"
   },

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -1,20 +1,8 @@
 const axios = require('axios');
 
-const createServer = require('./helpers/server.js');
-
-const server = createServer();
-
-beforeAll(async () => {
-  await server.start();
-});
-
-afterAll(async () => {
-  await server.stop();
-});
-
 describe('/cep/v1 (E2E)', () => {
   test('Utilizando um CEP válido: 05010000', async () => {
-    const requestUrl = `${server.getUrl()}/api/cep/v1/05010000`;
+    const requestUrl = `${global.SERVER_URL}/api/cep/v1/05010000`;
     const response = await axios.get(requestUrl);
 
     expect(response.data).toEqual({
@@ -28,7 +16,7 @@ describe('/cep/v1 (E2E)', () => {
 
   test('Utilizando um CEP inexistente: 00000000', async () => {
     expect.assertions(2);
-    const requestUrl = `${server.getUrl()}/api/cep/v1/00000000`;
+    const requestUrl = `${global.SERVER_URL}/api/cep/v1/00000000`;
 
     try {
       await axios.get(requestUrl);
@@ -46,7 +34,7 @@ describe('/cep/v1 (E2E)', () => {
 
   test('Utilizando um CEP inválido: 999999999999999', async () => {
     expect.assertions(2);
-    const requestUrl = `${server.getUrl()}/api/cep/v1/999999999999999`;
+    const requestUrl = `${global.SERVER_URL}/api/cep/v1/999999999999999`;
 
     try {
       await axios.get(requestUrl);

--- a/tests/ddd-v1.test.js
+++ b/tests/ddd-v1.test.js
@@ -1,23 +1,12 @@
 const axios = require('axios');
 
-const createServer = require('./helpers/server.js');
-const server = createServer();
-
 const scenariosDdd = {
   sucess: require('./helpers/scenarios/ddd/success'),
   inexistent: require('./helpers/scenarios/ddd/inexistent'),
   incorrect: require('./helpers/scenarios/ddd/incorrect'),
 };
 
-const requestUrl = `${server.getUrl()}/api/ddd/v1`;
-
-beforeAll(async () => {
-  await server.start();
-});
-
-afterAll(async () => {
-  await server.stop();
-});
+const requestUrl = `${global.SERVER_URL}/api/ddd/v1`;
 
 describe.skip('api/ddd/v1 (E2E)', () => {
   test('Utilizando um DDD válido: 12', async () => {

--- a/tests/graphql-v1.test.js
+++ b/tests/graphql-v1.test.js
@@ -1,20 +1,8 @@
 const axios = require('axios');
 
-const createServer = require('./helpers/server.js');
-
-const server = createServer();
-
-beforeAll(async () => {
-  await server.start();
-});
-
-afterAll(async () => {
-  await server.stop();
-});
-
 describe('/graphql/v1 (E2E)', () => {
   test('Utilizando um CEP válido: 05010000', async () => {
-    const requestUrl = `${server.getUrl()}/api/graphql/v1`;
+    const requestUrl = `${global.SERVER_URL}/api/graphql/v1`;
     const response = await axios.post(requestUrl, {
       query: `query FetchCep($cep: String!){
                 cep(cep: $cep) {
@@ -46,7 +34,7 @@ describe('/graphql/v1 (E2E)', () => {
     // response para quando for um type "validation_error" ou "service_error"
     // Nesse caso aqui seria um "service_error":
     // "Todos os serviços de CEP retornaram erro."
-    const requestUrl = `${server.getUrl()}/api/graphql/v1`;
+    const requestUrl = `${global.SERVER_URL}/api/graphql/v1`;
     const response = await axios.post(requestUrl, {
       query: `query FetchCep($cep: String!){
                 cep(cep: $cep) {
@@ -74,7 +62,7 @@ describe('/graphql/v1 (E2E)', () => {
     // response para quando for um type "validation_error" ou "service_error"
     // Nesse caso aqui seria um "validation_error":
     // "CEP deve conter exatamente 8 caracteres."
-    const requestUrl = `${server.getUrl()}/api/graphql/v1`;
+    const requestUrl = `${global.SERVER_URL}/api/graphql/v1`;
     const response = await axios.post(requestUrl, {
       query: `query FetchCep($cep: String!){
                 cep(cep: $cep) {

--- a/tests/helpers/server/index.js
+++ b/tests/helpers/server/index.js
@@ -1,29 +1,17 @@
 const waitOn = require('wait-on');
 const childProcess = require('child_process');
 
-const environment = process.env.NODE_ENV || 'test';
-
 function createServer() {
   let localServerProcess;
-
-  function getUrl() {
-    if (process.env.NODE_ENV === 'ci') {
-      return process.env.PREVIEW_URL;
-    }
-
-    return 'http://localhost:3000';
-  }
 
   function startLocalServer() {
     return childProcess.exec('npm run dev');
   }
 
   function start() {
-    const statusUrl = `${getUrl()}/api/status/v1`;
+    const statusUrl = 'http://localhost:3000/api/status/v1';
 
-    if (environment === 'test') {
-      localServerProcess = startLocalServer();
-    }
+    localServerProcess = startLocalServer();
 
     return waitOn({
       resources: [statusUrl],
@@ -39,7 +27,6 @@ function createServer() {
   return {
     start,
     stop,
-    getUrl,
   };
 }
 

--- a/tests/helpers/server/setup.js
+++ b/tests/helpers/server/setup.js
@@ -1,0 +1,8 @@
+const createServer = require('./index.js');
+
+module.exports = async () => {
+  console.log('\n[Start] Global setup');
+  global.LOCAL_SERVER = createServer();
+  await global.LOCAL_SERVER.start();
+  console.log('[Done] Global setup');
+};

--- a/tests/helpers/server/teardown.js
+++ b/tests/helpers/server/teardown.js
@@ -1,0 +1,5 @@
+module.exports = async () => {
+  console.log('\n[Start] Global teardown');
+  await global.LOCAL_SERVER.stop();
+  console.log('[Done] Global teardown');
+};


### PR DESCRIPTION
# Descrição

Apesar da ideia de usar o Github actions testando contra uma URL real de um deployment da Vercel ser SENSACIONAL ela não estava funcionando corretamente sendo apenas possível ser acionada por colaboradores com escrita no repo original.

Para um projeto tradicional isso possivelmente seria o suficiente mas como estamos falando de um projeto open source em que o fluxo padrão é criar um fork e abrir um PR de um repo remoto para o original essa abordagem se mostrou mais problemática do que positiva.

Portanto a proposta é passar a testar contra um servidor local simplificando bastante o setup e a chance de problemas relativos ao setup dos forks. 