### PR TITLE
fix: change sonar analysis method

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,24 +27,3 @@ jobs:
         with:
           name: code-coverage-report
           path: reports/coverage/lcov.info
-
-  sonarcloud:
-    name: SonarCloud
-    needs: [e2e-tests]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Download a single artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: code-coverage-report
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=BrasilAPI_BrasilAPI&metric=alert_status)](https://sonarcloud.io/dashboard?id=BrasilAPI_BrasilAPI)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=BrasilAPI_BrasilAPI&metric=code_smells)](https://sonarcloud.io/dashboard?id=BrasilAPI_BrasilAPI)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=BrasilAPI_BrasilAPI&metric=coverage)](https://sonarcloud.io/dashboard?id=BrasilAPI_BrasilAPI)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=BrasilAPI_BrasilAPI&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=BrasilAPI_BrasilAPI)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=BrasilAPI_BrasilAPI&metric=security_rating)](https://sonarcloud.io/dashboard?id=BrasilAPI_BrasilAPI)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=BrasilAPI_BrasilAPI&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=BrasilAPI_BrasilAPI)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,0 @@
-sonar.organization=brasilapi
-sonar.projectKey=BrasilAPI_BrasilAPI
-sonar.projectName=BrasilAPI
-sonar.sources=.
-sonar.sourceEncoding=UTF-8
-sonar.javascript.lcov.reportPaths=reports/coverage/lcov.info
-sonar.tests=tests
-sonar.exclusions=**/node_modules/**,tests/**, jest.config.js


### PR DESCRIPTION
A análise do Sonar foi alterada pra opção SonarCloud Automatic Analysis, assim não temos problema de token quando o PR é feito a partir de um fork.

