### PR TITLE
chore: rename branch 'master' to 'main'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ Consiste em realizar o *fork* do repositório raiz, cloná-lo, realizar a altera
 `git fetch reporaiz`
 - Vá para sua branch:
 `git checkout my-branch`
-- Atualize sua branch com as alterações da master do repositório raiz
-`git pull --rebase reporaiz master`
+- Atualize sua branch com as alterações da main do repositório raiz
+`git pull --rebase reporaiz main`
 - Atualize o sua *branch* remota
 `git push origin mybranch`
 - Caso ocorra algum conflito ao fazer o `push`, você pode utilizar o comando

--- a/pages/docs/doc.json
+++ b/pages/docs/doc.json
@@ -10,7 +10,7 @@
     },
     "license": {
       "name": "MIT",
-      "url": "https://github.com/BrasilAPI/BrasilAPI/blob/master/LICENSE"
+      "url": "https://github.com/BrasilAPI/BrasilAPI/blob/main/LICENSE"
     }
   },
   "tags": [


### PR DESCRIPTION
Essa semana o Github implementou uma feature que facilita modificar nome de branch existente. Com ele os PRs e regras apontarão para a branch correta. 
Então não temos mais razão para utilizar esse nome ultrapassado de branch.

Para ler acesse [Support for renaming an existing branch](https://github.com/github/renaming/#renaming-existing-branches).

## Atenção
1. Antes de fazer o merge desse PR é preciso renomear a branch master para main utilizando a [ferramenta disponibilizada pelo Github.](https://github.com/github/renaming/#renaming-existing-branches)
1. Após o merge é preciso acessar o Vercel e verificar se precisa de algum ajuste devido a não existir mais a branch master.