### PR TITLE
Cria endpoint de feriados nacionais

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,49 @@ Busca de detalhes de pessoas jurídicas pelo número do CNPJ utilizando a [API M
 {"message": "CNPJ 000 inválido."}
 ```
 
+### Feriados nacionais
+Lista feriados nacionais de determinado ano.
+
+**GET** `https://brasilapi.com.br/api/feriados/v1/`**[ano]**
+
+#### Consulta com sucesso
+
+```json
+// GET https://brasilapi.com.br/api/feriados/v1/2021
+[
+  {
+    "date": "2021-01-01",
+    "name": "Confraternização mundial",
+    "type": "national"
+  },
+  {
+    "date": "2021-02-16",
+    "name": "Carnaval",
+    "type": "national"
+  },
+  // ...
+]
+```
+
+#### Consultas com erro
+
+```json
+// GET https://brasilapi.com.br/api/feriados/v1/3000
+// HTTP/1.1 404 Not Found
+{
+  "type": "feriados_range_error",
+  "message": "Ano fora do intervalo suportado entre 1900 e 2199."
+}
+```
+```json
+// GET https://brasilapi.com.br/api/feriados/v1/erro
+// HTTP/1.1 500 Internal Server Error
+{
+  "type": "feriados_error",
+  "message": "Erro ao calcular feriados."
+}
+```
+
 ## Termos de Uso
 O BrasilAPI é uma iniciativa feita de brasileiros para brasileiros, por favor, não abuse deste serviço. Estamos em beta e ainda elaborando os Termos de Uso, mas por enquanto por favor não utilize formas automatizadas para fazer "crawling" dos dados da API. Um exemplo prático disto é um dos maiores provedores de telefonia do Brasil estar revalidando, neste exato momento, todos os Ceps (de `00000000` até `99999999`) e estourando em 5 vezes o limite atual da nossa conta no servidor. O volume de consulta dever ter a natureza de uma pessoa real requisitando um determinado dado. E para consultas com um alto volume automatizado, iremos mais para frente fornecer alguma solução, como por exemplo, conseguir fazer o download de toda a base de Ceps em uma única request.
 

--- a/pages/api/feriados/v1/[ano].js
+++ b/pages/api/feriados/v1/[ano].js
@@ -1,0 +1,29 @@
+import microCors from 'micro-cors';
+import getHolidays from '../../../../services/holidays';
+
+const CACHE_CONTROL_HEADER_VALUE =
+  'max-age=0, s-maxage=86400, stale-while-revalidate, public';
+const cors = microCors();
+
+const action = (request, response) => {
+  try {
+    const holidays = getHolidays(request.query.ano);
+
+    response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
+    response.status(200).json(holidays);
+  } catch (error) {
+    if (error.message === 'Cannot calculate holidays.') {
+      response.status(404).json({
+        type: 'feriados_range_error',
+        message: 'Ano fora do intervalo suportado entre 1900 e 2199.',
+      });
+    } else {
+      response.status(500).json({
+        type: 'feriados_error',
+        message: 'Erro ao calcular feriados.',
+      });
+    }
+  }
+};
+
+export default cors(action);

--- a/pages/docs/doc.json
+++ b/pages/docs/doc.json
@@ -399,6 +399,120 @@
         }
       }
     },
+    "/feriados/v1/{ano}": {
+      "get": {
+        "tags": [
+          "Feriados nacionais"
+        ],
+        "summary": "Lista os feriados nacionais de determinado ano.",
+        "description": "Calcula os feriados móveis baseados na Páscoa e adiciona os feriados fixos",
+        "parameters": [
+          {
+            "name": "ano",
+            "description": "Ano para calcular os feriados.\n",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "example": [
+                  {
+                    "date": "2021-01-01",
+                    "name": "Confraternização mundial",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-02-16",
+                    "name": "Carnaval",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-04-02",
+                    "name": "Paixão de Cristo",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-04-04",
+                    "name": "Páscoa",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-04-21",
+                    "name": "Tiradentes",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-05-01",
+                    "name": "Dia do trabalho",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-06-03",
+                    "name": "Corpus Christi",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-09-07",
+                    "name": "Independência do Brasil",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-10-12",
+                    "name": "Nossa Senhora Aparecida",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-11-02",
+                    "name": "Finados",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-11-15",
+                    "name": "Proclamação da República",
+                    "type": "national"
+                  },
+                  {
+                    "date": "2021-12-25",
+                    "name": "Natal",
+                    "type": "national"
+                  }
+                ]
+              }
+            }
+          },
+          "404": {
+            "description": "Ano fora do intervalo suportado.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "type": "feriados_range_error",
+                  "message": "Ano fora do intervalo suportado entre 1900 e 2199."
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Erro inesperado.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "type": "feriados_error",
+                  "message": "Erro ao calcular feriados."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ibge/uf/v1": {
       "get": {
         "tags": [

--- a/services/holidays/index.js
+++ b/services/holidays/index.js
@@ -1,0 +1,123 @@
+/**
+ * Tabela da lua cheia de Páscoa, valida entre 1900 e 2199, inclusive.
+ * Contendo mês (indexado em 0) e dia.
+ */
+function getPascalFullMoonDates() {
+  return [
+    [3, 14],
+    [3, 3],
+    [2, 23],
+    [3, 11],
+    [2, 31],
+    [3, 18],
+    [3, 8],
+    [2, 28],
+    [3, 16],
+    [3, 5],
+    [2, 25],
+    [3, 13],
+    [3, 2],
+    [2, 22],
+    [3, 10],
+    [2, 30],
+    [3, 17],
+    [3, 7],
+    [2, 27],
+  ];
+}
+
+/**
+ * @param Date date
+ * @return string
+ */
+function formatDate(date) {
+  return date.toISOString().substr(0, 10);
+}
+
+/**
+ * Cálculo de feriados móveis baseados na Páscoa
+ *
+ * @see https://en.wikipedia.org/wiki/Computus
+ */
+export function getEasterHolidays(year) {
+  if (year < 1900 || year > 2199) {
+    throw new Error('Cannot calculate holidays.');
+  }
+  const pascalFullMoonMonthDay = getPascalFullMoonDates();
+  const [refMonth, refDay] = pascalFullMoonMonthDay[year % 19];
+  const movingDate = new Date(year, refMonth, refDay);
+  const holidays = [];
+  movingDate.setDate(movingDate.getDate() + 7 - movingDate.getDay());
+  holidays.push({
+    date: formatDate(movingDate),
+    name: 'Páscoa',
+    type: 'national',
+  });
+  movingDate.setDate(movingDate.getDate() - 2);
+  // Sexta feira Santa / Paixão de Cristo não é feriado nacional
+  movingDate.setDate(movingDate.getDate() - 45);
+  holidays.push({
+    date: formatDate(movingDate),
+    name: 'Carnaval',
+    type: 'national',
+  });
+  movingDate.setDate(movingDate.getDate() + 107);
+  holidays.push({
+    date: formatDate(movingDate),
+    name: 'Corpus Christi',
+    type: 'national',
+  });
+  return holidays;
+}
+
+/**
+ * Combina feriados móveis e fixos.
+ *
+ * Lei n° 6.802 de 30/06/1980
+ * - Nossa Senhora Aparecida
+ * Lei n° 662 de 06/04/1949
+ * - Confraternização mundial
+ * - Tiradentes
+ * - Dia do trabalho
+ * - Independência do Brasil
+ * - Finados
+ * - Proclamação da República
+ * - Natal
+ *
+ * Referência de https://github.com/pagarme/business-calendar/tree/master/src/brazil
+ */
+export function getNationalHolidays(year) {
+  const fixedHolidays = [
+    ['01-01', 'Confraternização mundial'],
+    ['04-21', 'Tiradentes'],
+    ['05-01', 'Dia do trabalho'],
+    ['09-07', 'Independência do Brasil'],
+    ['10-12', 'Nossa Senhora Aparecida'],
+    ['11-02', 'Finados'],
+    ['11-15', 'Proclamação da República'],
+    ['12-25', 'Natal'],
+  ];
+  return fixedHolidays.map(([date, name]) => ({
+    date: `${year}-${date}`,
+    name,
+    type: 'national',
+  }));
+}
+
+function sortByDate(holidays) {
+  return holidays.sort((a, b) => {
+    if (a.date > b.date) {
+      return 1;
+    }
+    if (a.date < b.date) {
+      return -1;
+    }
+    return 0;
+  });
+}
+
+export default function getHolidays(year) {
+  const easterHolidays = getEasterHolidays(year);
+  const nationalHolidays = getNationalHolidays(year);
+  return sortByDate([...easterHolidays, ...nationalHolidays]);
+}

--- a/tests/feriados-v1.test.js
+++ b/tests/feriados-v1.test.js
@@ -1,0 +1,229 @@
+const axios = require('axios');
+const crypto = require('crypto');
+
+describe('/feriados/v1 (E2E)', () => {
+  test('Feriados fixos com ano válido entre 1900 e 2199', async () => {
+    const year = 1900 + crypto.randomInt(2199 - 1900);
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/${year}`;
+    const { data } = await axios.get(requestUrl);
+
+    expect.assertions(1);
+    expect(data).toEqual(
+      expect.arrayContaining([
+        {
+          date: `${year}-01-01`,
+          name: 'Confraternização mundial',
+          type: 'national',
+        },
+        {
+          date: `${year}-04-21`,
+          name: 'Tiradentes',
+          type: 'national',
+        },
+        {
+          date: `${year}-05-01`,
+          name: 'Dia do trabalho',
+          type: 'national',
+        },
+        {
+          date: `${year}-09-07`,
+          name: 'Independência do Brasil',
+          type: 'national',
+        },
+        {
+          date: `${year}-10-12`,
+          name: 'Nossa Senhora Aparecida',
+          type: 'national',
+        },
+        {
+          date: `${year}-11-02`,
+          name: 'Finados',
+          type: 'national',
+        },
+        {
+          date: `${year}-11-15`,
+          name: 'Proclamação da República',
+          type: 'national',
+        },
+        {
+          date: `${year}-12-25`,
+          name: 'Natal',
+          type: 'national',
+        },
+      ])
+    );
+  });
+
+  test('Feriados móveis de 2010', async () => {
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2010`;
+    const { data } = await axios.get(requestUrl);
+
+    expect.assertions(1);
+    expect(data).toEqual(
+      expect.arrayContaining([
+        {
+          date: `2010-02-16`,
+          name: 'Carnaval',
+          type: 'national',
+        },
+        {
+          date: `2010-04-04`,
+          name: 'Páscoa',
+          type: 'national',
+        },
+        {
+          date: `2010-06-03`,
+          name: 'Corpus Christi',
+          type: 'national',
+        },
+      ])
+    );
+  });
+
+  test('Feriados móveis de 2020', async () => {
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2020`;
+    const { data } = await axios.get(requestUrl);
+
+    expect.assertions(1);
+    expect(data).toEqual(
+      expect.arrayContaining([
+        {
+          date: `2020-02-25`,
+          name: 'Carnaval',
+          type: 'national',
+        },
+        {
+          date: `2020-04-12`,
+          name: 'Páscoa',
+          type: 'national',
+        },
+        {
+          date: `2020-06-11`,
+          name: 'Corpus Christi',
+          type: 'national',
+        },
+      ])
+    );
+  });
+
+  test('Feriados em ordem', async () => {
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2020`;
+    const { data } = await axios.get(requestUrl);
+
+    expect.assertions(1);
+    expect(data).toEqual([
+      {
+        date: `2020-01-01`,
+        name: 'Confraternização mundial',
+        type: 'national',
+      },
+      {
+        date: `2020-02-25`,
+        name: 'Carnaval',
+        type: 'national',
+      },
+      {
+        date: `2020-04-12`,
+        name: 'Páscoa',
+        type: 'national',
+      },
+      {
+        date: `2020-04-21`,
+        name: 'Tiradentes',
+        type: 'national',
+      },
+      {
+        date: `2020-05-01`,
+        name: 'Dia do trabalho',
+        type: 'national',
+      },
+      {
+        date: `2020-06-11`,
+        name: 'Corpus Christi',
+        type: 'national',
+      },
+      {
+        date: `2020-09-07`,
+        name: 'Independência do Brasil',
+        type: 'national',
+      },
+      {
+        date: `2020-10-12`,
+        name: 'Nossa Senhora Aparecida',
+        type: 'national',
+      },
+      {
+        date: `2020-11-02`,
+        name: 'Finados',
+        type: 'national',
+      },
+      {
+        date: `2020-11-15`,
+        name: 'Proclamação da República',
+        type: 'national',
+      },
+      {
+        date: `2020-12-25`,
+        name: 'Natal',
+        type: 'national',
+      },
+    ]);
+  });
+
+  test('Utilizando um ano fora do intervalo suportado: 3000', async () => {
+    expect.assertions(2);
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/3000`;
+
+    try {
+      await axios.get(requestUrl);
+    } catch (error) {
+      const { response } = error;
+
+      expect(response.status).toBe(404);
+      expect(response.data).toMatchObject({
+        type: 'feriados_range_error',
+        message: 'Ano fora do intervalo suportado entre 1900 e 2199.',
+      });
+    }
+  });
+
+  test('Utilizando um ano inválido: "erro"', async () => {
+    expect.assertions(2);
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/erro`;
+
+    try {
+      await axios.get(requestUrl);
+    } catch (error) {
+      const { response } = error;
+
+      expect(response.status).toBe(500);
+      expect(response.data).toEqual({
+        type: 'feriados_error',
+        message: 'Erro ao calcular feriados.',
+      });
+    }
+  });
+
+  test('Tiradentes e Páscoa no mesmo dia (2019)', async () => {
+    expect.assertions(2);
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2019`;
+    const { data } = await axios.get(requestUrl);
+
+    expect.assertions(2);
+    expect(data).toHaveLength(11);
+    expect(data).toEqual(
+      expect.arrayContaining([
+        {
+          date: `2019-04-21`,
+          name: 'Páscoa',
+          type: 'national',
+        },
+        {
+          date: `2019-04-21`,
+          name: 'Tiradentes',
+          type: 'national',
+        },
+      ])
+    );
+  });
+});


### PR DESCRIPTION
Olá pessoal, antes de fazer esse _pull request_ eu fiz um levantamento da situação desse recurso:

- O recurso foi solicitado nas _issues_ #68 e #118, nas duas ocasiões foram mencionados feriados nacionais e municipais.
- Existe três _pull requests_ para esse recurso em revisão: #121, #161 e #169 

As considerações feitas nesses PR estão relacionadas às limitações de acessar uma API externa, então optei por uma abordagem diferente.

No primeiro momento gerar uma lista apenas dos feriados nacionais, por ano. Existem alguns algoritmos para calcular os feriados móveis (Carnaval, Páscoa e Corpus Christi) e eles estão bem documentados na [wikipedia][computus]. Usando esses algoritmos é possível gerar a lista sem depender de um serviço externo.

Posteriormente pensamos em fornecer os feriados estaduais e municipais, incrementando os recursos fornecidos.

---

Nesse _pull request_:
- criei um serviço para isolar a lógica do cálculo;
- inclui a documentação no README e na pagina `docs`;
- criei os testes E2E
![tests-passing](https://user-images.githubusercontent.com/5047991/107891067-1bf7bf80-6efb-11eb-8485-4322e73f7ea9.png)

O que vocês acham dessa abordagem/implementação?

[computus]: https://en.wikipedia.org/wiki/Computus
