### PR TITLE
Atualização da lib de ceps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3876,11 +3876,12 @@
       "dev": true
     },
     "cep-promise": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-3.0.9.tgz",
-      "integrity": "sha512-Jr2eFFlNxdz7E8asz/uEEevxwkZfyL/asBBrZeNb0lp2LsgG0Aqgpathc9RuJGjQgPt+ifEVXbSYIZie1rXKyA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.0.4.tgz",
+      "integrity": "sha512-IhQrbZ8T+OAQxqE2tq9PI0/lqVIso6llnTdKCsAhoO8CCjn32NhuUpXwM7phDNmSl5vAWpBkJJ2sAMnYVnTA3A==",
       "requires": {
-        "isomorphic-unfetch": "2.0.0"
+        "node-fetch": "2.6.1",
+        "unfetch": "4.1.0"
       }
     },
     "chalk": {
@@ -3931,14 +3932,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-    },
-    "cidades-promise": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cidades-promise/-/cidades-promise-1.2.3.tgz",
-      "integrity": "sha512-BS+FsfP3r4cn3/ocCyPMAj9t51uB+VCN5zcOCXcc3zmZ2qsXzdaODff+ka1sNDwd3ULxwyws9fmoyJkkpxV4LQ==",
-      "requires": {
-        "axios": "^0.19.2"
-      }
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -5005,14 +4998,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -7201,15 +7186,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-unfetch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-2.0.0.tgz",
-      "integrity": "sha1-9QFApMFj11grXzfxWRloxPgJpkU=",
-      "requires": {
-        "node-fetch": "^1.7.1",
-        "unfetch": "^3.0.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -10160,13 +10136,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-fetch-h2": {
       "version": "2.3.0",
@@ -13965,9 +13937,9 @@
       }
     },
     "unfetch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
-      "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
+      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "apollo-server-micro": "^2.11.0",
     "axios": "0.19.2",
-    "cep-promise": "3.0.9",
+    "cep-promise": "4.0.4",
     "core-js": "^3.6.5",
     "lodash": "^4.17.19",
     "micro-cors": "0.1.1",

--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -3,14 +3,14 @@ import cep from 'cep-promise';
 
 // max-age especifica quanto tempo o browser deve manter o valor em cache, em segundos.
 // s-maxage é uma header lida pelo servidor proxy (neste caso, Vercel).
-// stale-while-revalidate indica que o conteúdo da cache pode ser servido como "stale" e revalidado no background
+// stale-while-revalidate indica que o conteúdo da cache pode ser servido como 'stale" e revalidado no background
 //
 // Por que os valores abaixo?
 //
-// 1. O cache da Now é muito rápido e permite respostas em cerca de 10ms. O valor de
-//    um dia (86400 segundos) é suficiente para garantir performance e também que as
+// 1. O cache da Vercel é muito rápido e permite respostas em cerca de 10ms. O valor de
+//    dois dias (172800 segundos) é suficiente para garantir performance e também que as
 //    respostas estejam relativamente sincronizadas caso o governo decida atualizar os CEPs.
-// 2. O cache da Now é invalidado toda vez que um novo deploy é feito, garantindo que
+// 2. O cache da Vercel é invalidado toda vez que um novo deploy é feito, garantindo que
 //    todas as novas requisições sejam servidas pela implementação mais recente da API.
 // 3. Não há browser caching pois este tipo de API normalmente é utilizada uma vez só
 //    por um usuário. Se fizessemos caching, os valores ficariam lá guardados no browser
@@ -18,23 +18,20 @@ import cep from 'cep-promise';
 //    servisse fotos dos usuários, por exemplo. Além disso teríamos problemas com
 //    stale/out-of-date cache caso alterássemos a implementação da API.
 const CACHE_CONTROL_HEADER_VALUE =
-  'max-age=0, s-maxage=86400, stale-while-revalidate, public';
+  'max-age=0, s-maxage=172800, stale-while-revalidate, public';
 const cors = microCors();
+
+const providers = ['correios', 'viacep', 'widenet'];
 
 async function Cep(request, response) {
   const requestedCep = request.query.cep;
-  const clientIp =
-    request.headers['x-forwarded-for'] || request.connection.remoteAddress;
-
-  console.log({
-    url: request.url,
-    clientIp: clientIp,
-  });
 
   response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
 
   try {
-    const cepResult = await cep(requestedCep);
+    const cepResult = await cep(requestedCep, {
+      providers,
+    });
 
     response.status(200);
     response.json(cepResult);

--- a/pages/docs/index.js
+++ b/pages/docs/index.js
@@ -1,13 +1,11 @@
-import React from 'react'
+import React from 'react';
 import { RedocStandalone } from 'redoc';
-import Documentation from './doc.json'
+import Documentation from './doc.json';
 
 export default function index() {
   return (
     <div>
-      <RedocStandalone
-        specUrl={Documentation}
-      />
+      <RedocStandalone specUrl={Documentation} />
     </div>
-  )
+  );
 }

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -11,6 +11,7 @@ describe('/cep/v1 (E2E)', () => {
       city: 'São Paulo',
       neighborhood: 'Perdizes',
       street: 'Rua Caiubi',
+      service: expect.any(String),
     });
   });
 


### PR DESCRIPTION
# Descrição

Para melhorar a performance e a customização do endpoint de ceps atualizei para a versão `4.0.4` que permite um novo parâmetro contendo `providers` e esse não inclui o `brasilapi` como um possível provedor.

Obs: essa nova versão adiciona o campo `service` na resposta da consulta indicando de onde que foi encontrada a informação.

Obs2: aproveitei pra aumentar o cache de 1 pra 2 dias e atualizar um pouco os comentários.