### PR TITLE
redirect slack logo to issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </div>
 
 <div align="center">
-  <a href="https://join.slack.com/t/brasilapi/shared_invite/zt-l12s2b8k-r0SHGZV4YZSMfrzhydn8WA"><img src="https://files.readme.io/e23f0e0-Slack_RGB.png" width="160px"></a>
+  <a href="https://github.com/BrasilAPI/BrasilAPI/issues/186"><img src="https://files.readme.io/e23f0e0-Slack_RGB.png" width="160px"></a>
 </div>
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=BrasilAPI_BrasilAPI&metric=alert_status)](https://sonarcloud.io/dashboard?id=BrasilAPI_BrasilAPI)


### PR DESCRIPTION
Atualiza o Link do logo para a issue #186 

Como ainda não encontramos uma solução para gerar o invite do slack automágicamente, resolvi redirecionar o logo para a issue, que podemos editar o invite sem a necessidade de abrir PR's constantemente.