### PR TITLE
add filter banks by partial name

### DIFF
--- a/pages/api/banks/v1/index.js
+++ b/pages/api/banks/v1/index.js
@@ -8,22 +8,16 @@ const action = async (request, response) => {
     const { search } = request.query;
     const formatedSearch = search.toLowerCase();
 
-    const filteredBanks = [];
-
-    allBanksData.map((bank) => {
+    const filteredBanks = allBanksData.filter((bank) => {
       const { code, name } = bank;
 
       // Checagem se search é parte do código do banco (number)
-      const checkCode = String(code).toLowerCase().includes(formatedSearch);
+      const checkCode = String(code).toLowerCase().indexOf(formatedSearch) > -1;
 
       // Checagem se search é parte do nome do banco (string)
-      const checkName = String(name.toLowerCase()).includes(formatedSearch);
+      const checkName = String(name.toLowerCase()).indexOf(formatedSearch) > -1;
 
-      if (checkCode || checkName) {
-        filteredBanks.push(bank);
-      }
-
-      return bank;
+      return checkCode || checkName;
     });
 
     response.status(200);

--- a/pages/api/banks/v1/index.js
+++ b/pages/api/banks/v1/index.js
@@ -1,23 +1,22 @@
 import app from '@/app';
 import { getBanksData } from '@/services/banco-central';
 
+const checkSubstrings = (input, search) => {
+  return String(input).toLowerCase().includes(search.toLowerCase());
+};
+
 const action = async (request, response) => {
   const allBanksData = await getBanksData();
 
   if (request.query.search) {
     const { search } = request.query;
-    const formatedSearch = search.toLowerCase();
 
     const filteredBanks = allBanksData.filter((bank) => {
       const { code, name } = bank;
 
-      // Checagem se search é parte do código do banco (number)
-      const checkCode = String(code).toLowerCase().indexOf(formatedSearch) > -1;
-
-      // Checagem se search é parte do nome do banco (string)
-      const checkName = String(name.toLowerCase()).indexOf(formatedSearch) > -1;
-
-      return checkCode || checkName;
+      return (
+        (checkSubstrings(code, search) || checkSubstrings(name, search)) && bank
+      );
     });
 
     response.status(200);

--- a/pages/api/banks/v1/index.js
+++ b/pages/api/banks/v1/index.js
@@ -4,8 +4,21 @@ import { getBanksData } from '@/services/banco-central';
 const action = async (request, response) => {
   const allBanksData = await getBanksData();
 
-  response.status(200);
-  response.json(allBanksData);
+  if (request.query.search) {
+    const { search } = request.query;
+
+    const filteredBanks = allBanksData.filter(
+      ({ code, name }) =>
+        String(code).toLowerCase().includes(search.toLowerCase()) ||
+        String(name.toLowerCase()).includes(search.toLowerCase())
+    );
+
+    response.status(200);
+    response.json(filteredBanks);
+  } else {
+    response.status(200);
+    response.json(allBanksData);
+  }
 };
 
 export default app().get(action);

--- a/pages/api/banks/v1/index.js
+++ b/pages/api/banks/v1/index.js
@@ -1,31 +1,28 @@
 import app from '@/app';
 import { getBanksData } from '@/services/banco-central';
 
-const checkSubstrings = (input, search) => {
+const containStringCaseInsensitive = (input, search) => {
   return String(input).toLowerCase().includes(search.toLowerCase());
 };
 
 const action = async (request, response) => {
-  const allBanksData = await getBanksData();
+  let banksData = await getBanksData();
 
   if (request.query.search) {
     const { search } = request.query;
 
-    const filteredBanks = allBanksData.filter((bank) => {
+    banksData = banksData.filter((bank) => {
       const { code, name } = bank;
 
       return (
-        (checkSubstrings(code, search) || checkSubstrings(name, search)) && bank
+        containStringCaseInsensitive(code, search) ||
+        containStringCaseInsensitive(name, search)
       );
     });
-
-    response.status(200);
-    response.json(filteredBanks);
-    return response;
   }
 
   response.status(200);
-  response.json(allBanksData);
+  response.json(banksData);
   return response;
 };
 

--- a/pages/api/banks/v1/index.js
+++ b/pages/api/banks/v1/index.js
@@ -6,19 +6,34 @@ const action = async (request, response) => {
 
   if (request.query.search) {
     const { search } = request.query;
+    const formatedSearch = search.toLowerCase();
 
-    const filteredBanks = allBanksData.filter(
-      ({ code, name }) =>
-        String(code).toLowerCase().includes(search.toLowerCase()) ||
-        String(name.toLowerCase()).includes(search.toLowerCase())
-    );
+    const filteredBanks = [];
+
+    allBanksData.map((bank) => {
+      const { code, name } = bank;
+
+      // Checagem se search é parte do código do banco (number)
+      const checkCode = String(code).toLowerCase().includes(formatedSearch);
+
+      // Checagem se search é parte do nome do banco (string)
+      const checkName = String(name.toLowerCase()).includes(formatedSearch);
+
+      if (checkCode || checkName) {
+        filteredBanks.push(bank);
+      }
+
+      return bank;
+    });
 
     response.status(200);
     response.json(filteredBanks);
-  } else {
-    response.status(200);
-    response.json(allBanksData);
+    return response;
   }
+
+  response.status(200);
+  response.json(allBanksData);
+  return response;
 };
 
 export default app().get(action);

--- a/pages/docs/doc.json
+++ b/pages/docs/doc.json
@@ -147,9 +147,7 @@
     },
     "/cep/v1/{cep}": {
       "get": {
-        "tags": [
-          "CEP"
-        ],
+        "tags": ["CEP"],
         "summary": "Busca por CEP com múltiplos providers de fallback.",
         "description": "",
         "parameters": [
@@ -208,9 +206,7 @@
     },
     "/ddd/v1/{ddd}": {
       "get": {
-        "tags": [
-          "DDD"
-        ],
+        "tags": ["DDD"],
         "summary": "Retorna estado e lista de cidades por DDD",
         "description": "",
         "parameters": [
@@ -230,8 +226,7 @@
             "description": "Success",
             "content": {
               "application/json": {
-                "example":
-                {
+                "example": {
                   "state": "SP",
                   "cities": [
                     "EMBU",
@@ -307,8 +302,7 @@
             "description": "DDD não encontrado",
             "content": {
               "application/json": {
-                "example":
-                {
+                "example": {
                   "name": "ddd_error",
                   "message": "DDD não encontrado",
                   "type": "DDD_NOT_FOUND"
@@ -320,8 +314,7 @@
             "description": "Todos os serviços de DDD retornaram erro.",
             "content": {
               "application/json": {
-                "example":
-                {
+                "example": {
                   "name": "ddd_error",
                   "message": "Todos os serviços de DDD retornaram erro.",
                   "type": "service_error"
@@ -332,12 +325,10 @@
         }
       }
     },
-    "/banks/v1": {
+    "/banks/v1?search={search}": {
       "get": {
-        "tags": [
-          "BANKS"
-        ],
-        "summary": "Retorna informações de todos os bancos do Brasil",
+        "tags": ["BANKS"],
+        "summary": "Retorna informações de todos os bancos do Brasil. Aceita, opcionalmente, o query params 'search' que pode ser parte do nome ou código do banco.",
         "description": "",
         "responses": {
           "200": {
@@ -366,9 +357,7 @@
     },
     "/banks/v1/{code}": {
       "get": {
-        "tags": [
-          "BANKS"
-        ],
+        "tags": ["BANKS"],
         "summary": "Busca as informações de um banco a partir de um código",
         "description": "",
         "responses": {
@@ -401,9 +390,7 @@
     },
     "/feriados/v1/{ano}": {
       "get": {
-        "tags": [
-          "Feriados nacionais"
-        ],
+        "tags": ["Feriados nacionais"],
         "summary": "Lista os feriados nacionais de determinado ano.",
         "description": "Calcula os feriados móveis baseados na Páscoa e adiciona os feriados fixos",
         "parameters": [
@@ -515,9 +502,7 @@
     },
     "/ibge/uf/v1": {
       "get": {
-        "tags": [
-          "IBGE"
-        ],
+        "tags": ["IBGE"],
         "summary": "Retorna informações de todos estados do Brasil",
         "description": "",
         "responses": {
@@ -555,9 +540,7 @@
     },
     "/ibge/uf/v1/{code}": {
       "get": {
-        "tags": [
-          "IBGE"
-        ],
+        "tags": ["IBGE"],
         "summary": "Busca as informações de um um estado a partir da sigla ou código",
         "description": "",
         "responses": {

--- a/tests/banks-v1.test.js
+++ b/tests/banks-v1.test.js
@@ -61,6 +61,12 @@ describe('banks v1 (E2E)', () => {
           code: null,
           fullName: 'Câmara Interbancária de Pagamentos',
         },
+        {
+          ispb: '15111975',
+          name: 'IUGU SERVICOS NA INTERNET S/A',
+          code: 401,
+          fullName: 'IUGU SERVICOS NA INTERNET S/A',
+        },
       ];
 
       expect(response.status).toBe(200);

--- a/tests/banks-v1.test.js
+++ b/tests/banks-v1.test.js
@@ -33,11 +33,30 @@ describe('banks v1 (E2E)', () => {
     });
   });
 
-  test('GET /banks/v1', async () => {
-    const requestUrl = `${global.SERVER_URL}/api/banks/v1`;
-    const response = await axios.get(requestUrl);
+  describe('GET /banks/v1/:code', () => {
+    test('Listar todos os bancos', async () => {
+      const requestUrl = `${global.SERVER_URL}/api/banks/v1`;
+      const response = await axios.get(requestUrl);
 
-    expect(response.status).toBe(200);
-    expect(Array.isArray(response.data)).toBe(true);
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.data)).toBe(true);
+    });
+
+    test('Listar bancos por parte de nome ou código', async () => {
+      const queryName = 'inter';
+
+      const requestUrl = `${global.SERVER_URL}/api/banks/v1?search=${queryName}`;
+      const response = await axios.get(requestUrl);
+
+      const filterNamesFromBanks = response.data.map(
+        ({ name }) =>
+          !!String(name).toLowerCase().includes(queryName.toLowerCase())
+      );
+
+      expect(response.status).toBe(200);
+      expect(
+        filterNamesFromBanks.every((nameCheck) => nameCheck === true)
+      ).toBe(true);
+    });
   });
 });

--- a/tests/banks-v1.test.js
+++ b/tests/banks-v1.test.js
@@ -42,21 +42,66 @@ describe('banks v1 (E2E)', () => {
       expect(Array.isArray(response.data)).toBe(true);
     });
 
-    test('Listar bancos por parte de nome ou código', async () => {
-      const queryName = 'inter';
+    test('Listar bancos por parte de nome', async () => {
+      const search = 'inter';
 
-      const requestUrl = `${global.SERVER_URL}/api/banks/v1?search=${queryName}`;
+      const requestUrl = `${global.SERVER_URL}/api/banks/v1?search=${search}`;
       const response = await axios.get(requestUrl);
 
-      const filterNamesFromBanks = response.data.map(
-        ({ name }) =>
-          !!String(name).toLowerCase().includes(queryName.toLowerCase())
-      );
+      const expectedResponse = [
+        {
+          ispb: '00416968',
+          name: 'BANCO INTER',
+          code: 77,
+          fullName: 'Banco Inter S.A.',
+        },
+        {
+          ispb: '04391007',
+          name: 'CAMARA INTERBANCARIA DE PAGAMENTOS - CIP',
+          code: null,
+          fullName: 'Câmara Interbancária de Pagamentos',
+        },
+      ];
 
       expect(response.status).toBe(200);
-      expect(
-        filterNamesFromBanks.every((nameCheck) => nameCheck === true)
-      ).toBe(true);
+      expect(response.data).toStrictEqual(expectedResponse);
+    });
+
+    test('Listar bancos por parte do código', async () => {
+      const search = 77;
+
+      const requestUrl = `${global.SERVER_URL}/api/banks/v1?search=${search}`;
+      const response = await axios.get(requestUrl);
+
+      const expectedResponse = [
+        {
+          ispb: '00416968',
+          name: 'BANCO INTER',
+          code: 77,
+          fullName: 'Banco Inter S.A.',
+        },
+        {
+          ispb: '17826860',
+          name: 'BMS SCD S.A.',
+          code: 377,
+          fullName: 'BMS SOCIEDADE DE CRÉDITO DIRETO S.A.',
+        },
+        {
+          ispb: '33042953',
+          name: 'CITIBANK N.A.',
+          code: 477,
+          fullName: 'Citibank N.A.',
+        },
+        {
+          ispb: '65913436',
+          name: 'GUIDE',
+          code: 177,
+          fullName: 'Guide Investimentos S.A. Corretora de Valores',
+        },
+      ];
+
+      expect(response.status).toBe(200);
+      expect(response.data).toStrictEqual(expectedResponse);
     });
   });
 });


### PR DESCRIPTION
# Descrição

Esse PR adiciona a possibilidade de filtrar os bancos retornados por querystring, utilizando o parâmetro `search` como por exemplo em `banks/v1?search=itau`.

