### PR TITLE
Atualiza API para Minha Receita

### DIFF
--- a/services/cnpj.js
+++ b/services/cnpj.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 export const getCnpjData = async (cnpj) => {
-  const url = 'https://minhareceita.org/';
-  const response = await axios({ url, method: 'post', data: `cnpj=${cnpj}` });
+  const response = await axios.get(`https://minhareceita.org/${cnpj}`);
   return response;
 };

--- a/tests/cnpj-v1.test.js
+++ b/tests/cnpj-v1.test.js
@@ -20,7 +20,9 @@ describe('api/cnpj/v1 (E2E)', () => {
 
       expect(status).toEqual(404);
       expect(data).toEqual({
-        message: 'CNPJ 00000000000000 não encontrado.',
+        message: 'CNPJ 00.000.000/0000-00 não encontrado.',
+        name: 'NotFoundError',
+        type: 'not_found',
       });
     }
   });
@@ -35,6 +37,8 @@ describe('api/cnpj/v1 (E2E)', () => {
       expect(status).toEqual(400);
       expect(data).toEqual({
         message: 'CNPJ 123 inválido.',
+        name: 'BadRequestError',
+        type: 'bad_request',
       });
     }
   });


### PR DESCRIPTION
A partir da excelente discussão em #208, acabei mudando algumas coisas no [Minha Receita](https://minhareceita.org) (ainda não lançadas), que incluem:

* Busca por requisição GET, e não POST
* Retorno 404 para CNPJ não encontrado, e não 204
* Compatibilidade reversa com requisições POST utilizando redirecionamento com retorno 303

Com isso, nada quebra no BrasilAPI, mas seria legal atualizar para evitar redirecionamento e excluir código desnecessário. Não utilizei `v2` na estrutura pois:
* a Minha Receita (como projeto ainda em _beta_) não tem versionamento ainda
* as mudanças previstas oferecem compatibilidade reversa
* a API para os usuários do BrasilAPI não muda nada

O que acham?

Vou deixar como rascunho aqui até eu fazer o lançamento lá, assim vamos conversando sobre como manter esse serviço alinhado : )