### PR TITLE
Feature/readme contributors update

### DIFF
--- a/.github/update-contributors
+++ b/.github/update-contributors
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+FILE=$1
+
+if [ ! -f "$FILE" ];
+then
+  echo 'Please provide a valid readme file'
+  exit 1
+fi
+
+START_POSITION=$(grep -n '<!-- contributors-start -->' $FILE | awk -F ':' '{ print $1 }')
+START_OCCURENCES=$(echo "$START_POSITION" | wc -l)
+END_POSITION=$(grep -n '<!-- contributors-end -->' $FILE | awk -F ':' '{ print $1 }')
+END_OCCURENCES=$(echo "$END_POSITION" | wc -l)
+
+if [ $START_OCCURENCES -ne 1 ] || [ $END_OCCURENCES -ne 1 ] || [ $START_POSITION -ge $END_POSITION ];
+then
+  echo 'Bad contributors placeholders'
+  exit 1
+fi;
+
+SELF_DIR="$(realpath `dirname $0`)/"
+CONTRIB_MARKDOWN="$($SELF_DIR/../node_modules/.bin/githubcontrib --owner BrasilAPI --repo BrasilAPI --sortBy contributions --sortOrder desc --filter filipedeschamps,lucianopf,dependabot[bot] --layoutStrategy $SELF_DIR/contributors-list/layout-strategy-custom.js)"
+
+NEW_README=$(head -n $START_POSITION $FILE)
+NEW_README="$NEW_README\n$CONTRIB_MARKDOWN"
+NEW_README="$NEW_README\n$(tail -n +$END_POSITION $FILE)"
+
+echo -e "$NEW_README" > $FILE
+
+echo "$FILE updated"

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,31 @@
+name: Update contributor on README
+
+on: [workflow_dispatch]
+
+jobs:
+  update-contributors:
+    name: Update contributor on README
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install npm packages
+        run: npm install
+
+      - name: Fetch contributor and update README
+        run: npm run contributors:update
+
+      - name: Add and commit
+        uses: EndBug/add-and-commit@v7
+        with:
+          add: 'README.md'
+          author_name: BrasilAPI CI
+          author_email: brasilapi@noreply.github.com
+          message: 'docs(contributors): Update project contributors'

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:watch": "jest --watch",
     "fix": "eslint . --ext .js --fix",
     "commit": "cz",
-    "gen:contributors": "githubcontrib --owner BrasilAPI --repo BrasilAPI --sortBy contributions --sortOrder desc --filter filipedeschamps,lucianopf,dependabot[bot] --layoutStrategy $INIT_CWD/.github/contributors-list/layout-strategy-custom.js"
+    "contributors:update": ".github/update-contributors README.md"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Inspirado pela _issue_ #302 e pelo trabalho do Lorhan na PR #314 realizei a automação da atualização de contribuidores usando o script já existente no projeto.

Nessa PR a criei um `shell script` para obter a tabela atualizada de pessoas que contribuíram, identificar os marcadores de inicio e fim e substituir a tabela existente pela nova. Com isso atualizei também o script no npm, que agora passa a ser executado com `npm run contributors:update`.

Configurei também um _action_ do GitHub para automatizar o processo usando o script npm atualizado e a _action_ [_Add & Commit_](https://github.com/marketplace/actions/add-commit).

O _workflow_ está configurado para execução manual, pensei em colocar ao fazer _commit_ na ramificação principal mas em dias em que vários PRs são aprovados seria executado várias vezes, poluindo o histórico. Dessa forma as pessoas com acesso podem iniciar a execução manualmente ([artigo para saber mais](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)):
![workflow manual](https://user-images.githubusercontent.com/5047991/121098302-f0f7eb00-c7cb-11eb-8203-6cd85ed67195.png)

No meu _fork_ configurei a _action_ na ramificação "readme-contributors-update-post-commit". O log da execução de teste pode ser visto [aqui](https://github.com/pedrosancao/BrasilAPI/runs/2768888073?check_suite_focus=true) e o _commit_ criado automaticamente foi o [d1cb988](https://github.com/pedrosancao/BrasilAPI/commit/d1cb98809dc092b0db073eca996d2d536509fdc2).

---

### Testando

Infelizmente só é possível testar _actions_ do GitHub ao subir o arquivo yml na ramificação principal do repositório. Quem quiser ver o _workflow_ em ação pode configurar em seu próprio _fork_ com os comandos abaixo (executados na pasta local do fork):

```bash
git checkout master-bkp origin/master
git remote add pedrosancao https://github.com/pedrosancao/BrasilAPI.git
git fetch pedrosancao
git checkout pedrosancao/0307562
git push -f origin HEAD:master
```
Inicie a tarefa manualmente conforme a imagem acima.

Para restaurar seu _fork_ para o estado anterior execute `git push -f origin master-bkp:master && git checkout master`