### PR TITLE
Fix code smell at getFipePrice function

### DIFF
--- a/services/fipe/price.js
+++ b/services/fipe/price.js
@@ -109,7 +109,7 @@ export async function getFipePrice(
     fipeCode,
   });
 
-  const result = await Promise.all(
+  return Promise.all(
     models.map((model) => {
       return getPrice({
         referenceTable: referenceTableCode,
@@ -119,6 +119,4 @@ export async function getFipePrice(
       });
     })
   );
-
-  return result;
 }


### PR DESCRIPTION
Fix "Immediately return this expression instead of assigning it to the temporary variable 'result'" code smell

### SonarCloud reference:

![image](https://user-images.githubusercontent.com/52456089/124531090-22240500-dde4-11eb-9108-9f9be21940ab.png)
