### PR TITLE
docs: remove botão duplicado do header

### DIFF
--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -14,11 +14,8 @@ export function Header() {
           height="45"
         />
         <div className={styles.ctas}>
-          <a
-            href="https://github.com/BrasilAPI/BrasilAPI"
-            className={styles.button}
-          >
-            Github
+          <a href="https://github.com/BrasilAPI/BrasilAPI" aria-label="Github">
+            <FaGithub color="#1A2E46" />
           </a>
         </div>
       </div>

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -14,11 +14,11 @@ export function Header() {
           height="45"
         />
         <div className={styles.ctas}>
-          <a href="https://github.com/BrasilAPI/BrasilAPI" aria-label="Github">
-            <FaGithub color="#1A2E46" />
-          </a>
-          <a href="/docs" className={styles.button}>
-            Documentação
+          <a
+            href="https://github.com/BrasilAPI/BrasilAPI"
+            className={styles.button}
+          >
+            Github
           </a>
         </div>
       </div>


### PR DESCRIPTION
Neste pull request eu removi o botão "Documentação" e troquei ele pelo do github,
com isso o "Começar agora" direciona para as docs e o "Github", para o github.

ao contrario do atual onde

o botão "Documentação" leva para as docs e o "Começar agora" tambem leva para as docs