### PR TITLE
feat: adiciona sexta-feira santa aos feriados nacionais

### DIFF
--- a/services/holidays/index.js
+++ b/services/holidays/index.js
@@ -61,7 +61,11 @@ export function getEasterHolidays(year) {
     type: 'national',
   });
   movingDate.setDate(movingDate.getDate() - 2);
-  // Sexta feira Santa / Paixão de Cristo não é feriado nacional
+  holidays.push({
+    date: formatDate(movingDate),
+    name: 'Sexta-feira Santa',
+    type: 'national',
+  });
   movingDate.setDate(movingDate.getDate() - 45);
   holidays.push({
     date: formatDate(movingDate),

--- a/tests/feriados-v1.test.js
+++ b/tests/feriados-v1.test.js
@@ -81,7 +81,7 @@ describe('/feriados/v1 (E2E)', () => {
 
     expect.assertions(2);
 
-    expect(data).toHaveLength(11);
+    expect(data).toHaveLength(12);
     expect(data).toEqual(
       expect.arrayContaining(getHolidays(2019, ['Páscoa', 'Tiradentes']))
     );

--- a/tests/helpers/feriados/index.js
+++ b/tests/helpers/feriados/index.js
@@ -9,12 +9,23 @@ const pascoaDaysByYear = {
   2010: '2010-04-04',
 };
 
+const goodFridayDaysByYear = {
+  2020: '2020-04-10',
+  2019: '2019-04-19',
+  2010: '2010-04-02',
+};
+
 const corpusChristiDaysByYear = {
   2020: '2020-06-11',
   2010: '2010-06-03',
 };
 
-const easterHolidaysName = ['Carnaval', 'Páscoa', 'Corpus Christi'];
+const easterHolidaysName = [
+  'Carnaval',
+  'Páscoa',
+  'Sexta-feira Santa',
+  'Corpus Christi',
+];
 const fixedHolidaysName = [
   'Confraternização mundial',
   'Tiradentes',
@@ -36,6 +47,11 @@ const getEasterHolidays = (year, holidaysName = easterHolidaysName) =>
     {
       date: pascoaDaysByYear[year],
       name: 'Páscoa',
+      type: 'national',
+    },
+    {
+      date: goodFridayDaysByYear[year],
+      name: 'Sexta-feira Santa',
       type: 'national',
     },
     {


### PR DESCRIPTION
A implementação adiciona o feriado de sexta-feira santa a lista de feriados nacionais e que atende a [issue](https://github.com/BrasilAPI/BrasilAPI/issues/403).