### PR TITLE
Code improvements for not found errors

### DIFF
--- a/pages/api/ddd/v1/[ddd].js
+++ b/pages/api/ddd/v1/[ddd].js
@@ -15,8 +15,6 @@ async function citiesOfDdd(request, response, next) {
     const dddData = allDddData.filter(({ ddd }) => ddd === requestedDdd);
 
     if (dddData.length === 0) {
-      response.status(404);
-
       throw new NotFoundError({
         message: 'DDD não encontrado',
         type: 'ddd_error',

--- a/pages/api/ibge/municipios/v1/[uf].js
+++ b/pages/api/ibge/municipios/v1/[uf].js
@@ -5,6 +5,9 @@ import { getStateCities, CODIGOS_ESTADOS } from '@/services/ibge/wikipedia';
 import { getContiesByUf } from '@/services/ibge/gov';
 
 import NotFoundError from '@/errors/NotFoundError';
+import InternalError from '@/errors/InternalError';
+import BaseError from '@/errors/BaseError';
+
 import { getCities } from '@/services/dados-abertos-br/cities';
 
 const getData = async (uf, providers = null) => {
@@ -40,17 +43,23 @@ const action = async (request, response) => {
       : null;
 
     if (!uf || !CODIGOS_ESTADOS[uf.toUpperCase()]) {
-      throw new Error('EstadoNotFoundException');
+      throw new NotFoundError({
+        message: 'UF não encontrada.',
+        name: 'EstadoNotFoundException',
+      });
     }
 
     const data = await getData(uf, providers);
     return response.status(200).json(data);
   } catch (err) {
-    if (err.message === 'EstadoNotFoundException') {
-      throw new NotFoundError({ message: 'UF não encontrada' });
+    if (err instanceof BaseError) {
+      throw err;
     }
 
-    throw err;
+    throw new InternalError({
+      message: 'Erro ao buscar UF.',
+      name: 'EstadoInternalException',
+    });
   }
 };
 

--- a/pages/api/ibge/uf/v1/[code].js
+++ b/pages/api/ibge/uf/v1/[code].js
@@ -7,13 +7,7 @@ const action = async (request, response) => {
   const { data, status } = await getUfByCode(code);
 
   if (Array.isArray(data) && !data.length) {
-    response.status(404);
-
-    throw new NotFoundError({
-      name: 'NotFoundError',
-      message: 'UF não encontrado.',
-      type: 'not_found',
-    });
+    throw new NotFoundError({ message: 'UF não encontrada.' });
   }
 
   response.status(status);

--- a/pages/api/taxas/v1/[sigla].js
+++ b/pages/api/taxas/v1/[sigla].js
@@ -9,11 +9,8 @@ const action = async (request, response) => {
   const valor = taxas[sigla];
 
   if (!valor) {
-    response.status(404);
     throw new NotFoundError({
-      name: 'NotFoundError',
       message: 'Taxa ou Índice não encontrada.',
-      type: 'not_found',
     });
   }
 

--- a/pages/docs/doc/ibge.json
+++ b/pages/docs/doc/ibge.json
@@ -219,7 +219,7 @@
                                 },
                                 "example": {
                                     "name": "NotFoundError",
-                                    "message": "UF não encontrado",
+                                    "message": "UF não encontrada.",
                                     "type": "not_found"
                                 }
                             }

--- a/tests/ibge-uf-v1.test.js
+++ b/tests/ibge-uf-v1.test.js
@@ -94,7 +94,7 @@ describe('/ibge/uf/v1 (E2E)', () => {
       expect(response.status).toBe(404);
       expect(response.data).toMatchObject({
         name: 'NotFoundError',
-        message: 'UF não encontrado.',
+        message: 'UF não encontrada.',
         type: 'not_found',
       });
     }


### PR DESCRIPTION
Olá! Fiz algumas padronizações pequenas para apis que usam a classe `NotFoundError`, dentre as minhas alterações estão:

- Padronização nas mensagens de erro para a api `ibge`
- Removido o status 404 sendo setado manualmente, a pŕopria exception já retorna o status correto
- Sugestão de melhoria em como a exception esta sendo disparada na api `ibge`, segui conforme demais APIs