### PR TITLE
Adiciona o provedor correios-alt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "apollo-server-micro": "2.24.0",
         "axios": "0.21.1",
         "bluebird": "3.7.2",
-        "cep-promise": "4.1.0",
+        "cep-promise": "4.3.0",
         "cors": "2.8.5",
         "graphql": "15.5.0",
         "lodash": "4.17.21",
@@ -3317,12 +3317,50 @@
       "dev": true
     },
     "node_modules/cep-promise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.1.0.tgz",
-      "integrity": "sha512-8Xe8nNtTnumMFnKkdO7mFwbJLdJek4JXku0M+AUE6tXPuaHSp/ea5MgSWA/P7K74C1H3okLy0xUWxC9F/90+bA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.3.0.tgz",
+      "integrity": "sha512-n/4VwYkRQ0KGjUvCt/aHwBewAEYAGGzmAAnmsMydpJBC5eMdsALyTZEfJFru9i+ElAspGz4OGpLRBFvp9RNbFw==",
       "dependencies": {
-        "node-fetch": "2.6.1",
+        "node-fetch": "2.6.7",
         "unfetch": "4.1.0"
+      }
+    },
+    "node_modules/cep-promise/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cep-promise/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/cep-promise/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/cep-promise/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/chalk": {
@@ -18986,12 +19024,41 @@
       "dev": true
     },
     "cep-promise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.1.0.tgz",
-      "integrity": "sha512-8Xe8nNtTnumMFnKkdO7mFwbJLdJek4JXku0M+AUE6tXPuaHSp/ea5MgSWA/P7K74C1H3okLy0xUWxC9F/90+bA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.3.0.tgz",
+      "integrity": "sha512-n/4VwYkRQ0KGjUvCt/aHwBewAEYAGGzmAAnmsMydpJBC5eMdsALyTZEfJFru9i+ElAspGz4OGpLRBFvp9RNbFw==",
       "requires": {
-        "node-fetch": "2.6.1",
+        "node-fetch": "2.6.7",
         "unfetch": "4.1.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "apollo-server-micro": "2.24.0",
     "axios": "0.21.1",
     "bluebird": "3.7.2",
-    "cep-promise": "4.1.0",
+    "cep-promise": "4.3.0",
     "cors": "2.8.5",
     "graphql": "15.5.0",
     "lodash": "4.17.21",

--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -4,7 +4,7 @@ import app from '@/app';
 import BadRequestError from '@/errors/BadRequestError';
 import NotFoundError from '@/errors/NotFoundError';
 
-const providers = ['correios', 'viacep', 'widenet'];
+const providers = ['correios', 'viacep', 'widenet', 'correios-alt'];
 
 async function Cep(request, response) {
   try {

--- a/pages/api/cep/v2/[cep].js
+++ b/pages/api/cep/v2/[cep].js
@@ -3,7 +3,7 @@ import cepPromise from 'cep-promise';
 
 import fetchGeocoordinateFromBrazilLocation from '../../../../lib/fetchGeocoordinateFromBrazilLocation';
 
-const providers = ['correios', 'viacep', 'widenet'];
+const providers = ['correios', 'viacep', 'widenet', 'correios-alt'];
 
 const CACHE_CONTROL_HEADER_VALUE =
   'max-age=0, s-maxage=86400, stale-while-revalidate, public';


### PR DESCRIPTION
Atualiza a biblioteca cep-promise para a versão 4.3.0 e adiciona o provedor `correios-alt`