### PR TITLE
refactor: renomeia nome do server para facilitar os reviews

### DIFF
--- a/pages/docs/doc/basic_info.json
+++ b/pages/docs/doc/basic_info.json
@@ -25,7 +25,7 @@
     ],
     "servers": [
         {
-            "url": "https://brasilapi.com.br/api"
+            "url": "/api"
         }
     ]
 }


### PR DESCRIPTION
Enquanto estava fazendo os reviews notei que ao tentar copiar e colocar um link de path que tem na documentação todos eles iniciavam com brasilapi.com.br e por conta disso era necessário trocar o path manualmente. Com essa mudança isso não será mais necessário

## Antes
![image](https://user-images.githubusercontent.com/16273730/208248001-81952df9-6c16-4cfb-982d-506f17f1a762.png)


## Depois

![image](https://user-images.githubusercontent.com/16273730/208247967-4b845d9c-8baa-41dc-ac14-0a6f4763dab8.png)
