### PR TITLE
Adicionando ddd no retorno da busca pelo cep referente a issue aberta #416

### DIFF
--- a/pages/docs/doc/cep.json
+++ b/pages/docs/doc/cep.json
@@ -144,6 +144,7 @@
                     "neighborhood",
                     "street",
                     "service",
+                    "ddd",
                     "location"
                 ],
                 "type": "object",
@@ -166,6 +167,9 @@
                     "service": {
                         "type": "string"
                     },
+                    "ddd": {
+                      "type": "string"
+                    },
                     "location": {
                         "schema": {
                             "$ref": "#/components/schemas/Location"
@@ -179,6 +183,7 @@
                     "neighborhood": "Centro",
                     "street": "Rua Doutor Luiz de Freitas Melro",
                     "service": "viacep",
+                    "ddd": "47",
                     "location": {
                         "type": "Point",
                         "coordinates": {


### PR DESCRIPTION
A alteração consiste na adição de uma função que busca o DDD da região pelo nome da cidade retornado pelo end-point ja existente do cep, utilizei os recursos ja existentes no módulo de ddd.