### PR TITLE
feat: Add launch.json to debug tests/dev on vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,9 +105,6 @@ dist
 
 .now
 
-# IDE
-.vscode/
-
 # Vercel
 .vercel
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,44 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/index.js",
+            "env": {
+                "NODE_PATH": ".",
+                "NODE_ENV": "LOCAL",
+                "NODE_INSTANCE": ""
+            },
+            "outputCapture": "std"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "NPM run test",
+            "runtimeExecutable": "npm",
+            "console": "integratedTerminal",
+            "runtimeArgs": [
+                "run-script",
+                "test",
+                "--"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "NPM run dev",
+            "runtimeExecutable": "npm",
+            "console": "integratedTerminal",
+            "runtimeArgs": [
+                "run-script",
+                "dev",
+                "--"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adicionado arquivo que nos possibilita poder fazer o debug direto no vscode tanto dos testes quando do desenvolvimento.
Foi removido o ignore do .vscode