### PR TITLE
Atualiza a lib cep-promise para a versão 4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "apollo-server-micro": "2.24.0",
         "axios": "0.21.1",
         "bluebird": "3.7.2",
-        "cep-promise": "4.3.0",
+        "cep-promise": "4.4.0",
         "cors": "2.8.5",
         "dayjs": "1.11.7",
         "fast-xml-parser": "4.0.11",
@@ -3360,9 +3360,9 @@
       "dev": true
     },
     "node_modules/cep-promise": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.3.0.tgz",
-      "integrity": "sha512-n/4VwYkRQ0KGjUvCt/aHwBewAEYAGGzmAAnmsMydpJBC5eMdsALyTZEfJFru9i+ElAspGz4OGpLRBFvp9RNbFw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.4.0.tgz",
+      "integrity": "sha512-nWobjjNQ/xXJcO2c+16GW26AHAgHI3sINAxo8KUu5J+yeJP20grb7Cw6wMXcdFvqunlMn195Z5F5RltXPYhuSg==",
       "dependencies": {
         "node-fetch": "2.6.7",
         "unfetch": "4.1.0"
@@ -19029,9 +19029,9 @@
       "dev": true
     },
     "cep-promise": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.3.0.tgz",
-      "integrity": "sha512-n/4VwYkRQ0KGjUvCt/aHwBewAEYAGGzmAAnmsMydpJBC5eMdsALyTZEfJFru9i+ElAspGz4OGpLRBFvp9RNbFw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cep-promise/-/cep-promise-4.4.0.tgz",
+      "integrity": "sha512-nWobjjNQ/xXJcO2c+16GW26AHAgHI3sINAxo8KUu5J+yeJP20grb7Cw6wMXcdFvqunlMn195Z5F5RltXPYhuSg==",
       "requires": {
         "node-fetch": "2.6.7",
         "unfetch": "4.1.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "apollo-server-micro": "2.24.0",
     "axios": "0.21.1",
     "bluebird": "3.7.2",
-    "cep-promise": "4.3.0",
+    "cep-promise": "4.4.0",
     "cors": "2.8.5",
     "dayjs": "1.11.7",
     "fast-xml-parser": "4.0.11",


### PR DESCRIPTION
essa atualização alteração altera o endereço de busca da widenet, de:
`https://ws.apicep.com/busca-cep/api/cep/:cep.json` para:
`https://cdn.apicep.com/file/apicep/:cep.json`