### PR TITLE
Update fetchGeocoordinateFromBrazilLocation.js

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -10,14 +10,11 @@ function getAgent() {
   return cacheAgent;
 }
 
-async function fetchGeocoordinateFromBrazilLocation({ state, city, street }) {
+async function fetchGeocoordinateFromBrazilLocation({ cep }) {
   const agent = getAgent();
-  const encodedState = encodeURI(state);
-  const encodedCity = encodeURI(city);
-  const encodedStreet = encodeURI(street);
 
   const country = 'Brasil';
-  const queryString = `format=json&addressdetails=1&country=${country}&state=${encodedState}&city=${encodedCity}&street=${encodedStreet}&limit=1`;
+  const queryString = `format=json&addressdetails=1&country=${country}&postalcode=${cep}&limit=1`;
 
   const response = await fetch(
     `https://nominatim.openstreetmap.org/search/?${queryString}`,


### PR DESCRIPTION
Bom dia,
Parabéns pelo excelente trabalho.
Não tenho experiência com o GitHub, então peço desculpa caso tenha feito alguma besteira. Devido a consulta ser feita utilizando como parâmetros Estado, Cidade e Rua, a Geolocalização pode vir errada caso exista mais de uma rua com o mesmo nome na cidade. Como é o caso do CEP 20751-120.

A solução é realizar a consulta utilizando o próprio CEP, o que elimina a duplicidade.