### PR TITLE
Update fetchGeocoordinateFromBrazilLocation.js

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -10,14 +10,14 @@ function getAgent() {
   return cacheAgent;
 }
 
-async function fetchGeocoordinateFromBrazilLocation({ state, city, street }) {
+async function fetchGeocoordinateFromBrazilLocation({ state, city, street, cep }) {
   const agent = getAgent();
   const encodedState = encodeURI(state);
   const encodedCity = encodeURI(city);
   const encodedStreet = encodeURI(street);
 
   const country = 'Brasil';
-  const queryString = `format=json&addressdetails=1&country=${country}&state=${encodedState}&city=${encodedCity}&street=${encodedStreet}&limit=1`;
+  const queryString = `format=json&addressdetails=1&country=${country}&state=${encodedState}&city=${encodedCity}&street=${encodedStreet}&postalcode=${cep}&limit=1`;
 
   const response = await fetch(
     `https://nominatim.openstreetmap.org/search/?${queryString}`,


### PR DESCRIPTION
Boa noite,
A geolocalização retorna incorreta quando existe mais de uma rua com o mesmo nome na cidade. A solução é adicionar o parâmetro  "postalcode", passando o cep.