### PR TITLE
Lista de participantes do pix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bluebird": "3.7.2",
         "cep-promise": "4.3.0",
         "cors": "2.8.5",
+        "dayjs": "^1.11.7",
         "fast-xml-parser": "4.0.11",
         "graphql": "15.5.0",
         "lodash": "4.17.21",
@@ -4216,6 +4217,11 @@
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "node_modules/debug": {
       "version": "4.1.1",
@@ -19716,6 +19722,11 @@
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "debug": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "bluebird": "3.7.2",
         "cep-promise": "4.3.0",
         "cors": "2.8.5",
-        "dayjs": "^1.11.7",
+        "dayjs": "1.11.7",
         "fast-xml-parser": "4.0.11",
         "graphql": "15.5.0",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bluebird": "3.7.2",
     "cep-promise": "4.3.0",
     "cors": "2.8.5",
-    "dayjs": "^1.11.7",
+    "dayjs": "1.11.7",
     "fast-xml-parser": "4.0.11",
     "graphql": "15.5.0",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bluebird": "3.7.2",
     "cep-promise": "4.3.0",
     "cors": "2.8.5",
+    "dayjs": "^1.11.7",
     "fast-xml-parser": "4.0.11",
     "graphql": "15.5.0",
     "lodash": "4.17.21",

--- a/pages/api/pix/v1/participants.js
+++ b/pages/api/pix/v1/participants.js
@@ -2,17 +2,31 @@ import app from '@/app';
 import InternalError from '@/errors/InternalError';
 import { getParticipants, formatCsvFile } from '@/services/pix/participants';
 
+const obtainList = async (actual = true) => {
+  try {
+    const response = await getParticipants();
+
+    return response;
+  } catch (error) {
+    if (actual && error.response.status === 404) {
+      return getParticipants(false);
+    }
+
+    throw error;
+  }
+};
+
 const action = async (request, response) => {
   let pixParticipantsList = '';
 
   try {
-    pixParticipantsList = await getParticipants();
+    pixParticipantsList = await obtainList();
   } catch (error) {
-    console.log(error.toJSON());
     throw new InternalError({
       status: 500,
       message: `Erro ao obter as informações do BCB`,
       name: 'PIX_LIST_ERROR',
+      type: 'PIX_LIST_ERROR',
     });
   }
 

--- a/pages/api/pix/v1/participants.js
+++ b/pages/api/pix/v1/participants.js
@@ -1,0 +1,20 @@
+import app from '@/app';
+import InternalError from '@/errors/InternalError';
+import { participants } from '@/services/pix/participants';
+
+const action = async (request, response) => {
+  try {
+    const data = await participants();
+
+    response.status(200);
+    response.json(data);
+  } catch (error) {
+    throw new InternalError({
+      status: 500,
+      message: 'Erro ao obter as informações do BCB',
+      name: 'PIX_LIST_ERROR',
+    });
+  }
+};
+
+export default app({ cache: 21600 }).get(action);

--- a/pages/api/pix/v1/participants.js
+++ b/pages/api/pix/v1/participants.js
@@ -1,20 +1,25 @@
 import app from '@/app';
 import InternalError from '@/errors/InternalError';
-import { participants } from '@/services/pix/participants';
+import { getParticipants, formatCsvFile } from '@/services/pix/participants';
 
 const action = async (request, response) => {
-  try {
-    const data = await participants();
+  let pixParticipantsList = '';
 
-    response.status(200);
-    response.json(data);
+  try {
+    pixParticipantsList = await getParticipants();
   } catch (error) {
+    console.log(error.toJSON());
     throw new InternalError({
       status: 500,
-      message: 'Erro ao obter as informações do BCB',
+      message: `Erro ao obter as informações do BCB`,
       name: 'PIX_LIST_ERROR',
     });
   }
+
+  const parsedData = formatCsvFile(pixParticipantsList);
+
+  response.status(200);
+  response.json(parsedData);
 };
 
 export default app({ cache: 21600 }).get(action);

--- a/pages/api/pix/v1/participants.js
+++ b/pages/api/pix/v1/participants.js
@@ -1,16 +1,16 @@
 import app from '@/app';
 import BaseError from '@/errors/BaseError';
 import InternalError from '@/errors/InternalError';
-import { getParticipants, formatCsvFile } from '@/services/pix/participants';
+import { getPixParticipants, formatCsvFile } from '@/services/pix/participants';
 
-const obtainList = async (actual = true) => {
+const obtainPixParticipantList = async (actual = true) => {
   try {
-    const response = await getParticipants();
+    const response = await getPixParticipants();
 
     return response;
   } catch (error) {
     if (actual && error.response.status === 404) {
-      return getParticipants(false);
+      return getPixParticipants(false);
     }
 
     throw new InternalError({
@@ -24,7 +24,7 @@ const obtainList = async (actual = true) => {
 
 const action = async (request, response) => {
   try {
-    const pixParticipantsList = await obtainList();
+    const pixParticipantsList = await obtainPixParticipantList();
 
     const parsedData = formatCsvFile(pixParticipantsList);
 

--- a/pages/docs/doc/pix.json
+++ b/pages/docs/doc/pix.json
@@ -65,10 +65,10 @@
         "required": [
           "ispb",
           "nome",
-          "nomeReduzido",
-          "modalidadeParticipacao",
-          "tipoParticipacao",
-          "inicioOperacao"
+          "nome_reduzido",
+          "modalidade_participacao",
+          "tipo_participacao",
+          "inicio_operacao"
         ],
         "type": "object",
         "properties": {
@@ -80,19 +80,19 @@
             "type": "string",
             "description": "Nome do participante"
           },
-          "nomeReduzido": {
+          "nome_reduzido": {
             "type": "string",
             "description": "Nome reduzido do participante"
           },
-          "modalidadeParticipacao": {
+          "modalidade_participacao": {
             "type": "string",
             "description": "Modalidade de Participação"
           },
-          "tipoParticipacao": {
+          "tipo_participacao": {
             "type": "string",
             "description": "Tipo de participante"
           },
-          "inicioOperacao": {
+          "inicio_operacao": {
             "type": "string",
             "description": "Date de inicio da operação"
           }
@@ -100,10 +100,10 @@
         "example": {
           "ispb": "360305",
           "nome": "CAIXA ECONOMICA FEDERAL",
-          "nomeReduzido": "CAIXA ECONOMICA FEDERAL",
-          "modalidadeParticipacao": "PDCT",
-          "tipoParticipacao": "DRCT",
-          "inicioOperacao": "2020-11-03T09:30:00.000Z"
+          "nome_reduzido": "CAIXA ECONOMICA FEDERAL",
+          "modalidade_participacao": "PDCT",
+          "tipo_participacao": "DRCT",
+          "inicio_operacao": "2020-11-03T09:30:00.000Z"
         }
       }
     }

--- a/pages/docs/doc/pix.json
+++ b/pages/docs/doc/pix.json
@@ -9,7 +9,7 @@
     "/pix/v1/participants": {
       "get": {
         "tags": ["PIX"],
-        "summary": "Retorna informações de todos os participantes do PIX no dia atual",
+        "summary": "Retorna informações de todos os participantes do PIX no dia atual ou anterior",
         "description": "",
         "responses": {
           "200": {

--- a/pages/docs/doc/pix.json
+++ b/pages/docs/doc/pix.json
@@ -1,0 +1,111 @@
+{
+  "tags": [
+    {
+      "name": "PIX",
+      "description": "Informações referentes ao PIX"
+    }
+  ],
+  "paths": {
+    "/pix/v1/participants": {
+      "get": {
+        "tags": ["PIX"],
+        "summary": "Retorna informações de todos os participantes do PIX no dia atual",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PIX_PARTICIPANTES"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Mensagem de erro"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "Tipo do erro"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Nome do erro"
+                    }
+                  },
+                  "example": {
+                    "message": "Erro ao obter as informações do BCB",
+                    "type": "internal",
+                    "name": "PIX_LIST_ERROR"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PIX_PARTICIPANTES": {
+        "title": "Pix Participantes",
+        "required": [
+          "ispb",
+          "nome",
+          "nomeReduzido",
+          "modalidadeParticipacao",
+          "tipoParticipacao",
+          "inicioOperacao"
+        ],
+        "type": "object",
+        "properties": {
+          "ispb": {
+            "type": "string",
+            "description": "ISPB"
+          },
+          "nome": {
+            "type": "string",
+            "description": "Nome do participante"
+          },
+          "nomeReduzido": {
+            "type": "string",
+            "description": "Nome reduzido do participante"
+          },
+          "modalidadeParticipacao": {
+            "type": "string",
+            "description": "Modalidade de Participação"
+          },
+          "tipoParticipacao": {
+            "type": "string",
+            "description": "Tipo de participante"
+          },
+          "inicioOperacao": {
+            "type": "string",
+            "description": "Date de inicio da operação"
+          }
+        },
+        "example": {
+          "ispb": "360305",
+          "nome": "CAIXA ECONOMICA FEDERAL",
+          "nomeReduzido": "CAIXA ECONOMICA FEDERAL",
+          "modalidadeParticipacao": "PDCT",
+          "tipoParticipacao": "DRCT",
+          "inicioOperacao": "2020-11-03T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,7 +14,7 @@ export default function Index() {
         <link rel="canonical" href="https://brasilapi.com.br/" />
         <meta
           name="keywords"
-          content="Brasil API, cep, ddd, bancos, cnpj, receita federal, ibge, feriados, tabela fipe, municípios, ncm, isbn"
+          content="Brasil API, cep, ddd, bancos, cnpj, receita federal, ibge, feriados, tabela fipe, municípios, ncm, isbn, pix"
         />
         <meta
           name="description"

--- a/pages/sitemap.xml/index.jsx
+++ b/pages/sitemap.xml/index.jsx
@@ -22,6 +22,7 @@ const getDocs = () => {
     'NCM',
     'ISBN',
     'CPTEC',
+    'PIX',
   ];
 };
 

--- a/services/date.js
+++ b/services/date.js
@@ -9,3 +9,7 @@ export const getNow = () => dayjs();
 
 export const formatDate = (date = dayjs(), format = 'DD/MM/YYYY') =>
   date.format(format);
+
+export const parseToDate = (value, format = '') => {
+  return dayjs(value, format).toDate();
+};

--- a/services/date.js
+++ b/services/date.js
@@ -1,0 +1,11 @@
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export const getNow = () => dayjs();
+
+export const formatDate = (date = dayjs(), format = 'DD/MM/YYYY') =>
+  date.format(format);

--- a/services/date.js
+++ b/services/date.js
@@ -5,6 +5,8 @@ const timezone = require('dayjs/plugin/timezone');
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+dayjs.tz.setDefault('America/Sao_Paulo');
+
 export const getNow = () => dayjs();
 
 export const formatDate = (date = dayjs(), format = 'DD/MM/YYYY') =>

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -8,8 +8,9 @@ const buildDate = () => {
   return formatDate(now, 'YYYYMMDD');
 };
 
-const getParticipants = async () => {
-  const csvPix = await axios.get(`${API_URL}${buildDate()}.csv`);
+export const getParticipants = async () => {
+  const url = `${API_URL}${buildDate()}.csv`;
+  const csvPix = await axios.get(url);
   return csvPix.data;
 };
 
@@ -20,7 +21,7 @@ const getParticipants = async () => {
  * @returns Lista de objetos com todos os dados dos participantes
  */
 
-const formatCsvFile = (file) => {
+export const formatCsvFile = (file) => {
   const LINE_BREAK = '\n';
   const lines = file.split(LINE_BREAK);
 
@@ -40,14 +41,4 @@ const formatCsvFile = (file) => {
       };
     })
     .filter(Boolean);
-};
-
-/**
- *
- * @returns Lista de objetos com todos os dados dos participantes
- */
-export const participants = async () => {
-  const data = await getParticipants();
-
-  return formatCsvFile(data);
 };

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -3,13 +3,12 @@ import { formatDate, getNow } from '../date';
 
 const API_URL = `https://www.bcb.gov.br/content/estabilidadefinanceira/spi/participantes-spi-`;
 
-const buildDate = () => {
-  const now = getNow();
-  return formatDate(now, 'YYYYMMDD');
-};
+const buildDate = (now = getNow()) => formatDate(now, 'YYYYMMDD');
 
-export const getParticipants = async () => {
-  const url = `${API_URL}${buildDate()}.csv`;
+export const getParticipants = async (fromToday = true) => {
+  const date = fromToday ? buildDate() : buildDate(getNow().subtract(1, 'day'));
+
+  const url = `${API_URL}${date}.csv`;
   const csvPix = await axios.get(url);
   return csvPix.data;
 };

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -9,7 +9,7 @@ const buildDate = (now = getNow()) => formatDate(now, 'YYYYMMDD');
 const isEqual = (a, b) =>
   a.length === b.length && a.every((v, i) => v === b[i]);
 
-export const getParticipants = async (fromToday = true) => {
+export const getPixParticipants = async (fromToday = true) => {
   const date = fromToday ? buildDate() : buildDate(getNow().subtract(1, 'day'));
 
   const url = `${API_URL}${date}.csv`;

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -1,27 +1,11 @@
 import axios from 'axios';
+import { formatDate, getNow } from '../date';
 
 const API_URL = `https://www.bcb.gov.br/content/estabilidadefinanceira/spi/participantes-spi-`;
 
-/**
- * Insere um 0 em meses <= 9 e em dias <= 9
- *
- * @param {string} value
- * @returns
- */
-const leadingZero = (value) => {
-  if (value > 9) return value;
-
-  return `0${value}`;
-};
-
 const buildDate = () => {
-  const now = new Date();
-
-  const year = now.getFullYear();
-  const month = leadingZero(now.getMonth() + 1);
-  const day = leadingZero(now.getDate());
-
-  return `${year}${month}${day}`;
+  const now = getNow();
+  return formatDate(now, 'YYYYMMDD');
 };
 
 const getParticipants = async () => {

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -44,7 +44,7 @@ export const formatCsvFile = (file) => {
 
   if (isEqual(headers, expectedHeaders)) {
     throw new BaseError({
-      status: 400,
+      status: 500,
       message: 'Dados e/ou cabeçalho do arquivo estão diferentes/atualizados',
     });
   }

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -33,10 +33,10 @@ export const formatCsvFile = (file) => {
       return {
         ispb: data[0],
         nome: data[1],
-        nomeReduzido: data[2],
-        modalidadeParticipacao: data[3],
-        tipoParticipacao: data[4],
-        inicioOperacao: data[5],
+        nome_reduzido: data[2],
+        modalidade_participacao: data[3],
+        tipo_participacao: data[4],
+        inicio_operacao: data[5],
       };
     })
     .filter(Boolean);

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -1,0 +1,69 @@
+import axios from 'axios';
+
+const API_URL = `https://www.bcb.gov.br/content/estabilidadefinanceira/spi/participantes-spi-`;
+
+/**
+ * Insere um 0 em meses <= 9 e em dias <= 9
+ *
+ * @param {string} value
+ * @returns
+ */
+const leadingZero = (value) => {
+  if (value > 9) return value;
+
+  return `0${value}`;
+};
+
+const buildDate = () => {
+  const now = new Date();
+
+  const year = now.getFullYear();
+  const month = leadingZero(now.getMonth() + 1);
+  const day = leadingZero(now.getDate());
+
+  return `${year}${month}${day}`;
+};
+
+const getParticipants = async () => {
+  const csvPix = await axios.get(`${API_URL}${buildDate()}.csv`);
+  return csvPix.data;
+};
+
+/**
+ * Parse dos dados obtidos do Banco Central
+ *
+ * @param {string} file CSV - Participantes do PIX
+ * @returns Lista de objetos com todos os dados dos participantes
+ */
+
+const formatCsvFile = (file) => {
+  const LINE_BREAK = '\n';
+  const lines = file.split(LINE_BREAK);
+
+  lines.shift();
+
+  return lines
+    .map((line) => line.split(';'))
+    .filter(([ispb]) => ispb)
+    .map((data) => {
+      return {
+        ispb: data[0],
+        nome: data[1],
+        nomeReduzido: data[2],
+        modalidadeParticipacao: data[3],
+        tipoParticipacao: data[4],
+        inicioOperacao: data[5],
+      };
+    })
+    .filter(Boolean);
+};
+
+/**
+ *
+ * @returns Lista de objetos com todos os dados dos participantes
+ */
+export const participants = async () => {
+  const data = await getParticipants();
+
+  return formatCsvFile(data);
+};

--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -1,9 +1,13 @@
+import BaseError from '@/errors/BaseError';
 import axios from 'axios';
-import { formatDate, getNow } from '../date';
+import { formatDate, getNow, parseToDate } from '../date';
 
 const API_URL = `https://www.bcb.gov.br/content/estabilidadefinanceira/spi/participantes-spi-`;
 
 const buildDate = (now = getNow()) => formatDate(now, 'YYYYMMDD');
+
+const isEqual = (a, b) =>
+  a.length === b.length && a.every((v, i) => v === b[i]);
 
 export const getParticipants = async (fromToday = true) => {
   const date = fromToday ? buildDate() : buildDate(getNow().subtract(1, 'day'));
@@ -24,20 +28,46 @@ export const formatCsvFile = (file) => {
   const LINE_BREAK = '\n';
   const lines = file.split(LINE_BREAK);
 
-  lines.shift();
+  const headers = lines
+    .shift()
+    .split(';')
+    .map((header) => header.toLowerCase());
 
-  return lines
-    .map((line) => line.split(';'))
-    .filter(([ispb]) => ispb)
-    .map((data) => {
-      return {
-        ispb: data[0],
-        nome: data[1],
-        nome_reduzido: data[2],
-        modalidade_participacao: data[3],
-        tipo_participacao: data[4],
-        inicio_operacao: data[5],
-      };
-    })
-    .filter(Boolean);
+  const expectedHeaders = [
+    'participantes',
+    'nomeParticipante',
+    'nomeReduzidoParticipante',
+    'modalidadeParticipacaoPix',
+    'tipoParticipanteSpi',
+    'dataHoraInicioOperacaoSpi',
+  ].map((header) => header.toLowerCase());
+
+  if (isEqual(headers, expectedHeaders)) {
+    throw new BaseError({
+      status: 400,
+      message: 'Dados e/ou cabeçalho do arquivo estão diferentes/atualizados',
+    });
+  }
+
+  try {
+    return lines
+      .map((line) => line.split(';'))
+      .filter(([ispb]) => ispb)
+      .map((data) => {
+        return {
+          ispb: data[0],
+          nome: data[1],
+          nome_reduzido: data[2],
+          modalidade_participacao: data[3],
+          tipo_participacao: data[4],
+          inicio_operacao: parseToDate(data[5]),
+        };
+      })
+      .filter(Boolean);
+  } catch (error) {
+    throw new BaseError({
+      status: 500,
+      message: 'Erro ao fazer o parse dos dados',
+    });
+  }
 };

--- a/tests/pix-v1.test.js
+++ b/tests/pix-v1.test.js
@@ -1,0 +1,24 @@
+const axios = require('axios');
+
+const requestUrl = `${global.SERVER_URL}/api/pix/v1/participants`;
+
+describe('api/pix/v1/participants (E2E)', () => {
+  test('should return full list', async () => {
+    const response = await axios.get(requestUrl);
+    const { data, status } = response;
+
+    expect(status).toEqual(200);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThanOrEqual(1);
+
+    expect.arrayContaining([
+      expect.objectContaining({
+        ispb: expect.any(String),
+        nome: expect.any(String),
+        nomeReduzido: expect.any(String),
+        modalidadeParticipacao: expect.any(String),
+        inicioOperacao: expect.any(String),
+      }),
+    ]);
+  });
+});

--- a/tests/pix-v1.test.js
+++ b/tests/pix-v1.test.js
@@ -15,9 +15,9 @@ describe('api/pix/v1/participants (E2E)', () => {
       expect.objectContaining({
         ispb: expect.any(String),
         nome: expect.any(String),
-        nomeReduzido: expect.any(String),
-        modalidadeParticipacao: expect.any(String),
-        inicioOperacao: expect.any(String),
+        nome_reduzido: expect.any(String),
+        modalidade_participacao: expect.any(String),
+        inicio_operacao: expect.any(String),
       }),
     ]);
   });


### PR DESCRIPTION
- Lista de participantes do pix, incluindo o ISPB de cada IP
- Parse + Transform do CSV gerado pelo BCB
- Cache de 6 horas, pois não sei em qual horário é gerado o csv com os dados
- Dados dos participantes são gerados diariamente seguindo o padrão informado na #333 (https://www.bcb.gov.br/content/estabilidadefinanceira/spi/participantes-spi-${yyyyMMdd}.csv)

Relativo a #333 #464