### PR TITLE
docs: fix typo at home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Caso você esteja lendo esta versão de README, você está pegando o projeto nu
 Veja mais detalhes sobre **Como contribuir** no arquivo [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Termos de Uso
-O BrasilAPI é uma iniciativa feita de brasileiros para brasileiros, por favor, não abuse deste serviço. Estamos em beta e ainda elaborando os Termos de Uso, mas por enquanto por favor não utilize formas automatizadas para fazer "crawling" dos dados da API. Um exemplo prático disto é um dos maiores provedores de telefonia do Brasil estar revalidando, neste exato momento, todos os Ceps (de `00000000` até `99999999`) e estourando em 5 vezes o limite atual da nossa conta no servidor. O volume de consulta dever ter a natureza de uma pessoa real requisitando um determinado dado. E para consultas com um alto volume automatizado, iremos mais para frente fornecer alguma solução, como por exemplo, conseguir fazer o download de toda a base de Ceps em uma única request.
+O BrasilAPI é uma iniciativa feita de brasileiros para brasileiros, por favor, não abuse deste serviço. Estamos em beta e ainda elaborando os Termos de Uso, mas por enquanto por favor não utilize formas automatizadas para fazer "crawling" dos dados da API. Um exemplo prático disto é um dos maiores provedores de telefonia do Brasil estar revalidando, neste exato momento, todos os Ceps (de `00000000` até `99999999`) e estourando em 5 vezes o limite atual da nossa conta no servidor. O volume de consulta deve ter a natureza de uma pessoa real requisitando um determinado dado. E para consultas com um alto volume automatizado, iremos mais para frente fornecer alguma solução, como por exemplo, conseguir fazer o download de toda a base de Ceps em uma única request.
 
 ## Pessoas que já contribuiram
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -112,7 +112,7 @@ export default function Index() {
             Um exemplo prático disto foi quando dos maiores provedores de
             telefonia do Brasil estava revalidando, todos os ceps (de 00000000
             até 99999999 ) e estourando em 5 vezes o limite atual da nossa conta
-            no servidor. O volume de consulta dever ter a natureza de uma pessoa
+            no servidor. O volume de consulta deve ter a natureza de uma pessoa
             real requisitando um determinado dado. E para consultas com um alto
             volume automatizado, iremos mais para frente fornecer alguma
             solução, como por exemplo, conseguir fazer o download de toda a base


### PR DESCRIPTION
This tiny PR fixes a typo in the last paragraph of the homepage. Where it reads "[...] O volume de consulta dever ter" it should read "[...] O volume de consulta deve ter".