### PR TITLE
fix: fetchGeo API url

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -25,7 +25,7 @@ async function fetchGeocoordinateFromBrazilLocation({
   const queryString = `format=json&addressdetails=1&country=${country}&state=${encodedState}&city=${encodedCity}&street=${encodedStreet}`;
 
   const response = await fetch(
-    `https://nominatim.openstreetmap.org/search/?${queryString}`,
+    `https://nominatim.openstreetmap.org/search?${queryString}`,
     { agent }
   );
 


### PR DESCRIPTION
A url da API nominatim.openstreetmap.org na função `fetchGeocoordinateFromBrazilLocation()` está retornando erro 500 devido a uma mudança no lado deles:

![image](https://github.com/BrasilAPI/BrasilAPI/assets/5108881/bcbb713c-5fbd-47a0-b58c-afc0bddd3991)
