### PR TITLE
feat: Investment Funds API

### DIFF
--- a/pages/api/cvm/fundos/v1/[cnpj].js
+++ b/pages/api/cvm/fundos/v1/[cnpj].js
@@ -1,0 +1,26 @@
+import app from '@/app';
+
+import BaseError from '@/errors/BaseError';
+
+import InternalError from '@/errors/InternalError';
+import { getFundDetails } from '@/services/cvm/fundos';
+
+const action = async (request, response) => {
+  try {
+    const cnpj = request.query.cnpj.replace(/\D/gim, '');
+    const fundDetails = await getFundDetails(cnpj);
+    response.status(200).json(fundDetails);
+  } catch (err) {
+    if (err instanceof BaseError) {
+      throw err;
+    }
+
+    throw new InternalError({
+      message: 'Erro ao buscar informações sobre fundos',
+      type: 'exchange_error',
+      name: 'EXCHANGE_INTERNAL',
+    });
+  }
+};
+
+export default app({ cache: 86400 }).get(action);

--- a/pages/api/cvm/fundos/v1/index.js
+++ b/pages/api/cvm/fundos/v1/index.js
@@ -1,0 +1,26 @@
+import app from '@/app';
+
+import BaseError from '@/errors/BaseError';
+
+import InternalError from '@/errors/InternalError';
+import { getFunds } from '@/services/cvm/fundos';
+
+const action = async (request, response) => {
+  try {
+    const { page, size } = request.query;
+    const fundData = await getFunds(size, page);
+    response.status(200).json(fundData);
+  } catch (err) {
+    if (err instanceof BaseError) {
+      throw err;
+    }
+
+    throw new InternalError({
+      message: 'Erro ao buscar informações sobre fundos',
+      type: 'exchange_error',
+      name: 'EXCHANGE_INTERNAL',
+    });
+  }
+};
+
+export default app({ cache: 86400 }).get(action);

--- a/pages/docs/doc/fundos.json
+++ b/pages/docs/doc/fundos.json
@@ -1,0 +1,334 @@
+{
+  "tags": [
+    {
+      "name": "Fundos de investimento",
+      "description": "Informações referentes a Fundos de investimentos registrados na CVM"
+    }
+  ],
+
+  "paths": {
+    "/cvm/fundos/v1": {
+      "get": {
+        "tags": ["Fundos", "Fundos de investimento"],
+        "summary": "Retorna lista de fundos de investimentos registrados na CVM.",
+        "description": "Lista de dados cadastrais de fundos de investimento estruturados e não Estruturados (ICVM 555/ICVM 175). São retornados fundos ativos e cancelados. Devido ao grande volume, utilizamos paginação para acesso dos dados. ",
+        "parameters": [
+          {
+            "name": "page",
+            "description": "Indica paginação necessária para pesquisa.\n",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "date"
+            }
+          },
+          {
+            "name": "size",
+            "description": "Tamanho de elementos em cada página (1 a 200).\n",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cvm/fundos/v1/{cnpj}": {
+      "get": {
+        "tags": ["Fundos", "Fundos de investimento"],
+        "summary": "Busca por detalhes de um registro de fundo na CVM.",
+        "description": "",
+        "parameters": [
+          {
+            "name": "cnpj",
+            "description": "O Cadastro Nacional da Pessoa Jurídica é um número único que identifica uma pessoa jurídica e outros tipos de arranjo jurídico sem personalidade jurídica junto à Receita Federal.\n",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Não foi encontrado este CNPJ na listagem da CVM.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "message": "Fundo não encontrado",
+                  "type": "not_found",
+                  "name": "NotFoundError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FundListResponse": {
+        "title": "Lista de fundos de investimento",
+        "required": ["data", "page", "size"],
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "schema": "#/components/schemas/FundListData"
+          },
+          "page": {
+            "type": "number"
+          },
+          "size": {
+            "type": "number"
+          }
+        },
+        "example": {
+          "data": [
+            {
+              "cnpj": "00.000.684/0001-21",
+              "denominacaoSocial": "DEUTSCHE BANK FDO APLIC QUOTAS FDO INV FINANCEIRO - MAX",
+              "codigoCvm": "19",
+              "tipoFundo": "FACFIF",
+              "situacao": "CANCELADA"
+            },
+            {
+              "cnpj": "00.000.731/0001-37",
+              "denominacaoSocial": "ITAMARITI CASH FUNDO APLICACAO QUOTAS FDOS INVESTIMENTO",
+              "codigoCvm": "40681",
+              "tipoFundo": "FACFIF",
+              "situacao": "CANCELADA"
+            },
+            {
+              "cnpj": "00.000.732/0001-81",
+              "denominacaoSocial": "FUNDO APLIC. QUOTAS DE F.I. SANTANDER CURTO PRAZO",
+              "codigoCvm": "27",
+              "tipoFundo": "FACFIF",
+              "situacao": "CANCELADA"
+            }
+          ],
+          "page": 1,
+          "size": 3
+        }
+      },
+      "FundListData": {
+        "title": "Lista de fundos de investimento",
+        "required": [
+          "cnpj",
+          "denominacaoSocial",
+          "codigoCvm",
+          "tipoFundo",
+          "situacao"
+        ],
+        "type": "object",
+        "properties": {
+          "cnpj": {
+            "type": "string"
+          },
+          "denominacaoSocial": {
+            "type": "string"
+          },
+          "codigoCvm": {
+            "type": "string"
+          },
+          "tipoFundo": {
+            "type": "string"
+          },
+          "situacao": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "data": [
+            {
+              "cnpj": "00.000.684/0001-21",
+              "denominacaoSocial": "DEUTSCHE BANK FDO APLIC QUOTAS FDO INV FINANCEIRO - MAX",
+              "codigoCvm": "19",
+              "tipoFundo": "FACFIF",
+              "situacao": "CANCELADA"
+            },
+            {
+              "cnpj": "00.000.731/0001-37",
+              "denominacaoSocial": "ITAMARITI CASH FUNDO APLICACAO QUOTAS FDOS INVESTIMENTO",
+              "codigoCvm": "40681",
+              "tipoFundo": "FACFIF",
+              "situacao": "CANCELADA"
+            },
+            {
+              "cnpj": "00.000.732/0001-81",
+              "denominacaoSocial": "FUNDO APLIC. QUOTAS DE F.I. SANTANDER CURTO PRAZO",
+              "codigoCvm": "27",
+              "tipoFundo": "FACFIF",
+              "situacao": "CANCELADA"
+            }
+          ],
+          "page": 1,
+          "size": "3"
+        }
+      },
+
+      "FundDetails": {
+        "title": "Detalhes de um fundo de investimento",
+        "required": [
+          "tipoFundo",
+          "cnpj",
+          "denominacaoSocial",
+          "dataRegistro",
+          "dataConstituicao",
+          "codigoCvm",
+          "dataCancelamento",
+          "situacao",
+          "dataInicioSituacao",
+          "dataInicioAtividade",
+          "dataInicioExercicio",
+          "dataFimExercicio",
+          "classe",
+          "dataInicioClasse",
+          "rentabilidade",
+          "condominio",
+          "cotas",
+          "fundoExclusivo",
+          "tributacaoLongoPrazo",
+          "publicoAlvo",
+          "entidadeInvestimento",
+          "taxaPerformance",
+          "informacaoTaxaPerformance",
+          "taxaAdministracao",
+          "informacaoTaxaAdministracao",
+          "valorPatrimonioLiquido",
+          "dataPatrimonioLiquido",
+          "diretor",
+          "cnpjAdministrador",
+          "administrador",
+          "tipoPessoaGestor",
+          "cpfCnpjGestor",
+          "gestor",
+          "cnpjAuditor",
+          "auditor",
+          "cnpjCustodiante",
+          "custodiante",
+          "cnpjControlador",
+          "controlador",
+          "investimentoExterno",
+          "classeAnbima"
+        ],
+        "type": "object",
+        "properties": {
+          "tipoFundo": { "type": "string" },
+          "cnpj": { "type": "string" },
+          "denominacaoSocial": { "type": "string" },
+          "dataRegistro": { "type": "string", "format": "date" },
+          "dataConstituicao": { "type": "string", "format": "date" },
+          "codigoCvm": { "type": "string" },
+          "dataCancelamento": { "type": "string", "format": "date" },
+          "situacao": { "type": "string" },
+          "dataInicioSituacao": { "type": "string", "format": "date" },
+          "dataInicioAtividade": { "type": "string", "format": "date" },
+          "dataInicioExercicio": { "type": "string", "format": "date" },
+          "dataFimExercicio": { "type": "string", "format": "date" },
+          "classe": { "type": "string" },
+          "dataInicioClasse": { "type": "string", "format": "date" },
+          "rentabilidade": { "type": "string" },
+          "condominio": { "type": "string" },
+          "cotas": { "type": "string" },
+          "fundoExclusivo": { "type": "string" },
+          "tributacaoLongoPrazo": { "type": "string" },
+          "publicoAlvo": { "type": "string" },
+          "entidadeInvestimento": { "type": "string" },
+          "taxaPerformance": { "type": "string" },
+          "informacaoTaxaPerformance": { "type": "string" },
+          "taxaAdministracao": { "type": "string" },
+          "informacaoTaxaAdministracao": { "type": "string" },
+          "valorPatrimonioLiquido": { "type": "string" },
+          "dataPatrimonioLiquido": { "type": "string", "format": "date" },
+          "diretor": { "type": "string" },
+          "cnpjAdministrador": { "type": "string" },
+          "administrador": { "type": "string" },
+          "tipoPessoaGestor": { "type": "string" },
+          "cpfCnpjGestor": { "type": "string" },
+          "gestor": { "type": "string" },
+          "cnpjAuditor": { "type": "string" },
+          "auditor": { "type": "string" },
+          "cnpjCustodiante": { "type": "string" },
+          "custodiante": { "type": "string" },
+          "cnpjControlador": { "type": "string" },
+          "controlador": { "type": "string" },
+          "investimentoExterno": { "type": "string" },
+          "classeAnbima": { "type": "string" }
+        },
+        "example": {
+          "tipoFundo": "FACFIF",
+          "cnpj": "00.000.732/0001-81",
+          "denominacaoSocial": "FUNDO APLIC. QUOTAS DE F.I. SANTANDER CURTO PRAZO",
+          "dataRegistro": "2003-04-30",
+          "dataConstituicao": "1994-05-24",
+          "codigoCvm": "27",
+          "dataCancelamento": "1999-09-03",
+          "situacao": "CANCELADA",
+          "dataInicioSituacao": "1999-09-03",
+          "dataInicioAtividade": null,
+          "dataInicioExercicio": null,
+          "dataFimExercicio": null,
+          "classe": null,
+          "dataInicioClasse": null,
+          "rentabilidade": null,
+          "condominio": null,
+          "cotas": null,
+          "fundoExclusivo": null,
+          "tributacaoLongoPrazo": null,
+          "publicoAlvo": null,
+          "entidadeInvestimento": null,
+          "taxaPerformance": null,
+          "informacaoTaxaPerformance": null,
+          "taxaAdministracao": null,
+          "informacaoTaxaAdministracao": null,
+          "valorPatrimonioLiquido": null,
+          "dataPatrimonioLiquido": null,
+          "diretor": null,
+          "cnpjAdministrador": null,
+          "administrador": null,
+          "tipoPessoaGestor": null,
+          "cpfCnpjGestor": null,
+          "gestor": null,
+          "cnpjAuditor": null,
+          "auditor": null,
+          "cnpjCustodiante": null,
+          "custodiante": null,
+          "cnpjControlador": null,
+          "controlador": null,
+          "investimentoExterno": null,
+          "classeAnbima": null
+        }
+      }
+    }
+  }
+}

--- a/services/cvm/fundos.js
+++ b/services/cvm/fundos.js
@@ -1,0 +1,121 @@
+import BadRequestError from '@/errors/BadRequestError';
+import NotFoundError from '@/errors/NotFoundError';
+import axios from 'axios';
+import { isNaN } from 'lodash';
+import Papa from 'papaparse';
+
+const changeHeader = (header) => {
+  const headerEnum = {
+    TP_FUNDO: 'tipoFundo',
+    CNPJ_FUNDO: 'cnpj',
+    DENOM_SOCIAL: 'denominacaoSocial',
+    DT_REG: 'dataRegistro',
+    DT_CONST: 'dataConstituicao',
+    CD_CVM: 'codigoCvm',
+    DT_CANCEL: 'dataCancelamento',
+    SIT: 'situacao',
+    DT_INI_SIT: 'dataInicioSituacao',
+    DT_INI_ATIV: 'dataInicioAtividade',
+    DT_INI_EXERC: 'dataInicioExercicio',
+    DT_FIM_EXERC: 'dataFimExercicio',
+    CLASSE: 'classe',
+    DT_INI_CLASSE: 'dataInicioClasse',
+    RENTAB_FUNDO: 'rentabilidade',
+    CONDOM: 'condominio',
+    FUNDO_COTAS: 'cotas',
+    FUNDO_EXCLUSIVO: 'fundoExclusivo',
+    TRIB_LPRAZO: 'tributacaoLongoPrazo',
+    PUBLICO_ALVO: 'publicoAlvo',
+    ENTID_INVEST: 'entidadeInvestimento',
+    TAXA_PERFM: 'taxaPerformance',
+    INF_TAXA_PERFM: 'informacaoTaxaPerformance',
+    TAXA_ADM: 'taxaAdministracao',
+    INF_TAXA_ADM: 'informacaoTaxaAdministracao',
+    VL_PATRIM_LIQ: 'valorPatrimonioLiquido',
+    DT_PATRIM_LIQ: 'dataPatrimonioLiquido',
+    DIRETOR: 'diretor',
+    CNPJ_ADMIN: 'cnpjAdministrador',
+    ADMIN: 'administrador',
+    PF_PJ_GESTOR: 'tipoPessoaGestor',
+    CPF_CNPJ_GESTOR: 'cpfCnpjGestor',
+    GESTOR: 'gestor',
+    CNPJ_AUDITOR: 'cnpjAuditor',
+    AUDITOR: 'auditor',
+    CNPJ_CUSTODIANTE: 'cnpjCustodiante',
+    CUSTODIANTE: 'custodiante',
+    CNPJ_CONTROLADOR: 'cnpjControlador',
+    CONTROLADOR: 'controlador',
+    INVEST_CEMPR_EXTER: 'investimentoExterno',
+    CLASSE_ANBIMA: 'classeAnbima',
+  };
+  return headerEnum[header];
+};
+
+const fetchCvmData = async () => {
+  const response = await axios.get(
+    'https://dados.cvm.gov.br/dados/FI/CAD/DADOS/cad_fi.csv',
+    { timeout: 3000, responseType: 'arraybuffer' }
+  );
+
+  const string = response.data.toString('latin1');
+
+  return string;
+};
+
+const parseCvmData = (data, opts = {}) => {
+  const parsedData = Papa.parse(data, {
+    header: true,
+    skipEmptyLines: true,
+    transformHeader: (header) => changeHeader(header),
+    transform: (value) => value || null,
+  });
+
+  if (opts.summary) {
+    return parsedData.data.map(
+      ({ cnpj, denominacaoSocial, tipoFundo, codigoCvm, situacao }) => ({
+        cnpj,
+        denominacaoSocial,
+        codigoCvm,
+        tipoFundo,
+        situacao,
+      })
+    );
+  }
+
+  return parsedData.data;
+};
+
+export const getFunds = async (size = 100, page = 1) => {
+  const offset = Number(page);
+  const pageSize = Number(size) > 200 ? 200 : Number(size);
+
+  if (isNaN(offset) || isNaN(size))
+    throw new BadRequestError({
+      message: 'Página e tamanho devem ser números inteiros',
+    });
+
+  const fundData = await fetchCvmData();
+
+  const parsedData = parseCvmData(fundData, { summary: true });
+
+  return {
+    data: parsedData.slice((offset - 1) * pageSize, offset * pageSize),
+    page: offset,
+    size: pageSize,
+  };
+};
+
+export const getFundDetails = async (cnpj) => {
+  const fundData = await fetchCvmData();
+
+  const parsedData = parseCvmData(fundData);
+
+  const fundDetails = parsedData.find(
+    (f) => f.cnpj.replace(/\D/gim, '') === cnpj
+  );
+
+  if (!fundDetails)
+    throw new NotFoundError({ message: 'Fundo não encontrado' });
+
+  return fundDetails;
+};

--- a/tests/fundos-v1.test.js
+++ b/tests/fundos-v1.test.js
@@ -1,0 +1,110 @@
+const axios = require('axios');
+
+expect.extend({
+  nullOrAny(received) {
+    return {
+      pass:
+        typeof received === 'string' ||
+        received instanceof String ||
+        received === null,
+      message: () =>
+        `expected null or string, but received ${this.utils.printReceived(
+          received
+        )}`,
+    };
+  },
+});
+const validOutputSchema = expect.objectContaining({
+  tipoFundo: expect.nullOrAny(),
+  cnpj: expect.nullOrAny(),
+  denominacaoSocial: expect.nullOrAny(),
+  dataRegistro: expect.nullOrAny(),
+  dataConstituicao: expect.nullOrAny(),
+  codigoCvm: expect.nullOrAny(),
+  dataCancelamento: expect.nullOrAny(),
+  situacao: expect.nullOrAny(),
+  dataInicioSituacao: expect.nullOrAny(),
+  dataInicioAtividade: expect.nullOrAny(),
+  dataInicioExercicio: expect.nullOrAny(),
+  dataFimExercicio: expect.nullOrAny(),
+  classe: expect.nullOrAny(),
+  dataInicioClasse: expect.nullOrAny(),
+  rentabilidade: expect.nullOrAny(),
+  condominio: expect.nullOrAny(),
+  cotas: expect.nullOrAny(),
+  fundoExclusivo: expect.nullOrAny(),
+  tributacaoLongoPrazo: expect.nullOrAny(),
+  publicoAlvo: expect.nullOrAny(),
+  entidadeInvestimento: expect.nullOrAny(),
+  taxaPerformance: expect.nullOrAny(),
+  informacaoTaxaPerformance: expect.nullOrAny(),
+  taxaAdministracao: expect.nullOrAny(),
+  informacaoTaxaAdministracao: expect.nullOrAny(),
+  valorPatrimonioLiquido: expect.nullOrAny(),
+  dataPatrimonioLiquido: expect.nullOrAny(),
+  diretor: expect.nullOrAny(),
+  cnpjAdministrador: expect.nullOrAny(),
+  administrador: expect.nullOrAny(),
+  tipoPessoaGestor: expect.nullOrAny(),
+  cpfCnpjGestor: expect.nullOrAny(),
+  gestor: expect.nullOrAny(),
+  cnpjAuditor: expect.nullOrAny(),
+  auditor: expect.nullOrAny(),
+  cnpjCustodiante: expect.nullOrAny(),
+  custodiante: expect.nullOrAny(),
+  cnpjControlador: expect.nullOrAny(),
+  controlador: expect.nullOrAny(),
+  investimentoExterno: expect.nullOrAny(),
+  classeAnbima: expect.nullOrAny(),
+});
+
+const validFunds = expect.objectContaining({
+  data: expect.arrayContaining([
+    expect.objectContaining({
+      cnpj: expect.any(String),
+      denominacaoSocial: expect.any(String),
+      codigoCvm: expect.any(String),
+      tipoFundo: expect.any(String),
+      situacao: expect.any(String),
+    }),
+  ]),
+  size: expect.any(Number),
+  page: expect.any(Number),
+});
+
+describe('funds v1 (E2E)', () => {
+  describe('GET /cvm/fundos/v1/:cnpj', () => {
+    test('Utilizando um CNPJ válido: 00000684000121', async () => {
+      const requestUrl = `${global.SERVER_URL}/api/cvm/fundos/v1/00000684000121`;
+      const response = await axios.get(requestUrl);
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual(validOutputSchema);
+    });
+
+    test('Utilizando um CNPJ inexistente: 1111111', async () => {
+      const requestUrl = `${global.SERVER_URL}/api/cvm/fundos/v1/1111111`;
+
+      try {
+        await axios.get(requestUrl);
+      } catch (error) {
+        const { response } = error;
+
+        expect(response.status).toBe(404);
+        expect(response.data).toMatchObject({
+          message: 'Fundo não encontrado',
+          type: 'not_found',
+          name: 'NotFoundError',
+        });
+      }
+    });
+  });
+
+  test('GET /cvm/fundos/v1', async () => {
+    const requestUrl = `${global.SERVER_URL}/api/cvm/fundos/v1`;
+    const response = await axios.get(requestUrl);
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual(validFunds);
+  });
+});


### PR DESCRIPTION
# API Fundos de Investimento

## [CVM] Dados Cadastrais

Criação de uma API que busca dados cadastrais de fundos de investimento na CVM, em sua planilha de Dados Cadastrais diários.

### Feature
Foram adicionadas duas rotas (seguindo padrão do endpoint de _corretoras_): 
- `GET cvm/fundos/v1?page=1&size=100` - busca por todos fundos já registrados na CVM - paginação implementada pelo tamanho da planilha.
- `GET cvm/fundos/v1/:cnpj` - Detalhes de dados de um fundo específico.

### Testes
Foram criados 3 testes e2e para assegurar o funcionamento dos endpoints criados.

### Documentação
Documentação também foi atualizada e testada na UI já implementada