### PR TITLE
fix: change `no-else-return` config in `.eslintrc.js`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,9 +24,12 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     'import/prefer-default-export': 'off',
-    'no-else-return': {
-      allowElseIf: true,
-    },
+    'no-else-return': [
+      2,
+      {
+        allowElseIf: true,
+      },
+    ],
   },
   settings: {
     'import/resolver': {


### PR DESCRIPTION
```
'no-else-return': {
      allowElseIf: true,
}
```
Essa configuração no `.eslintrc.js` estava gerando uma exceção ao rodar o eslint, então após ler a documentação encontrei a solução para o problema:
```
'no-else-return': [
      2,
      {
        allowElseIf: true,
      },
],
```
O `2` configura que se for encontrado um código com um else após um return, vai gerar um erro no eslint e impedir um possível commit. E o `allowElseIf` vai permitir um else if após um if com return.