### PR TITLE
Adiciona feriado nacional do dia da consciência negra a partir de 2024

### DIFF
--- a/services/holidays/index.js
+++ b/services/holidays/index.js
@@ -108,6 +108,14 @@ export function getNationalHolidays(year) {
     ['11-15', 'Proclamação da República'],
     ['12-25', 'Natal'],
   ];
+
+  if (year >= 2024) {
+    fixedHolidays.splice(fixedHolidays.length - 1, 0, [
+      '11-20',
+      'Dia da consciência negra',
+    ]);
+  }
+
   return fixedHolidays.map(([date, name]) => ({
     date: `${year}-${date}`,
     name,

--- a/tests/feriados-v1.test.js
+++ b/tests/feriados-v1.test.js
@@ -86,4 +86,30 @@ describe('/feriados/v1 (E2E)', () => {
       expect.arrayContaining(getHolidays(2019, ['Páscoa', 'Tiradentes']))
     );
   });
+
+  test('Feriado da consciência negra não deve existir em ano anterior a 2024', async () => {
+    expect.assertions(2);
+
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2023`;
+    const { data } = await axios.get(requestUrl);
+
+    expect(data).toHaveLength(12);
+    expect(data).toEqual(
+      expect.not.arrayContaining(
+        getHolidays(2024, ['Dia da consciência negra'])
+      )
+    );
+  });
+
+  test('Feriado da consciência negra deve existir a partir de 2024', async () => {
+    expect.assertions(2);
+
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2024`;
+    const { data } = await axios.get(requestUrl);
+
+    expect(data).toHaveLength(13);
+    expect(data).toEqual(
+      expect.arrayContaining(getHolidays(2024, ['Dia da consciência negra']))
+    );
+  });
 });

--- a/tests/helpers/feriados/index.js
+++ b/tests/helpers/feriados/index.js
@@ -34,6 +34,7 @@ const fixedHolidaysName = [
   'Nossa Senhora Aparecida',
   'Finados',
   'Proclamação da República',
+  'Dia da consciência negra',
   'Natal',
 ];
 
@@ -61,8 +62,8 @@ const getEasterHolidays = (year, holidaysName = easterHolidaysName) =>
     },
   ].filter(({ name }) => holidaysName.includes(name));
 
-const getFixedHolidays = (year, holidaysName = fixedHolidaysName) =>
-  [
+const getFixedHolidays = (year, holidaysName = fixedHolidaysName) => {
+  const holidays = [
     {
       date: `${year}-01-01`,
       name: 'Confraternização mundial',
@@ -103,7 +104,18 @@ const getFixedHolidays = (year, holidaysName = fixedHolidaysName) =>
       name: 'Natal',
       type: 'national',
     },
-  ].filter(({ name }) => holidaysName.includes(name));
+  ];
+
+  if (year >= 2024) {
+    holidays.splice(holidays.length - 1, 0, {
+      date: `${year}-11-20`,
+      name: 'Dia da consciência negra',
+      type: 'national',
+    });
+  }
+
+  return holidays.filter(({ name }) => holidaysName.includes(name));
+};
 
 const getHolidays = (
   year,


### PR DESCRIPTION
**Descrição**

A partir de 2024 o dia da consciência negra será considerado feriado nacional, pensando nisso fiz a inclusão do feriado a partir de 2024 no endpoint holidays.