### PR TITLE
feat: weather location cptec

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,11 +3,7 @@ import React from 'react';
 import '../styles/globals.scss';
 
 function MyApp({ Component, pageProps }) {
-  return (
-    <>
-      <Component {...pageProps} />
-    </>
-  );
+  return <Component {...pageProps} />;
 }
 
 export default MyApp;

--- a/pages/api/cep/v2/[cep].js
+++ b/pages/api/cep/v2/[cep].js
@@ -26,7 +26,7 @@ async function Cep(request, response) {
     if (!cepFromCepPromise.street) {
       cepFromCepPromise.street = null;
     }
-    
+
     if (!cepFromCepPromise.neighborhood) {
       cepFromCepPromise.neighborhood = null;
     }

--- a/pages/api/cptec/v1/clima/previsao/semana/[lat]/[long].js
+++ b/pages/api/cptec/v1/clima/previsao/semana/[lat]/[long].js
@@ -1,0 +1,60 @@
+import app from '@/app';
+import BadRequestError from '@/errors/BadRequestError';
+import BaseError from '@/errors/BaseError';
+import InternalError from '@/errors/InternalError';
+import NotFoundError from '@/errors/NotFoundError';
+import { getPredictionWeatherByLocation } from '@/services/cptec';
+
+const action = async (request, response) => {
+  const { lat, long } = request.query;
+
+  if (!Number.isFinite(Number(lat))) {
+    throw new BadRequestError({
+      message: 'Latitude inválida, informe um valor numérico',
+      type: 'request_error',
+      name: 'INVALID_POSITION_LAT',
+    });
+  }
+
+  if (!Number.isFinite(Number(long))) {
+    throw new BadRequestError({
+      message: 'Longitude inválida, informe um valor numérico',
+      type: 'request_error',
+      name: 'INVALID_POSITION_LONG',
+    });
+  }
+
+  try {
+    const weatherPredictions = await getPredictionWeatherByLocation(lat, long);
+
+    if (!weatherPredictions) {
+      throw new NotFoundError({
+        message: 'Cidade não localizada',
+        type: 'city_error',
+        name: 'CITY_NOT_FOUND',
+      });
+    }
+
+    if (weatherPredictions.clima.length === 0) {
+      throw new NotFoundError({
+        message: 'Previsões meteorológicas não localizadas',
+        type: 'weather_error',
+        name: 'WEATHER_PREDICTIONS_NOT_FOUND',
+      });
+    }
+
+    response.json(weatherPredictions);
+  } catch (err) {
+    if (err instanceof BaseError) {
+      throw err;
+    }
+
+    throw new InternalError({
+      message: 'Erro ao buscar previsões para a cidade',
+      type: 'weather_error',
+      name: 'CITY_WEATHER_PREDICTIONS_ERROR',
+    });
+  }
+};
+
+export default app().get(action);

--- a/pages/docs/doc/cptec.json
+++ b/pages/docs/doc/cptec.json
@@ -252,7 +252,54 @@
                 "deprecated": false
             }
         },
-        "/cptec/v1/ondas/{cityCode}": {
+        "/cptec/v1/clima/previsao/semana/{lat}/{long}": {
+            "get": {
+                "tags": ["CPTEC"],
+                "summary": "Previsão meteorológica com base na latitude e longitude",
+                "description": "Retorna a previsão meteorológica para a cidade com base na latitude e longitude informada para um período de até 7 dias.\nDevido a inconsistências encontradas nos retornos da CPTEC nossa API só consegue retornar com precisão o período máximo de 6 dias.",
+                "operationId": "upto7dayspredictionlocation(/cptec/v1/clima/previsao/semana/:lat/:long)",
+                "parameters": [
+                    {
+                        "name": "lat",
+                        "in": "path",
+                        "description": "Latitude de uma cidade",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "float",
+                            "format": "float32",
+                            "example": -22.90
+                        }
+                    },
+                    {
+                        "name": "long",
+                        "in": "path",
+                        "description": "Longitude de uma cidade",
+                        "required": true,
+                        "style": "simple",
+                        "schema": {
+                            "type": "float",
+                            "format": "float32",
+                            "example": -47.06
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "application/json; charset=utf-8": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ClimaPrediction"
+                                }
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+         "/cptec/v1/ondas/{cityCode}": {
             "get": {
                 "tags": ["CPTEC"],
                 "summary": "Previsão oceânica",

--- a/services/cptec/index.js
+++ b/services/cptec/index.js
@@ -3,6 +3,7 @@ import {
   getCurrentCapitalWeatherData,
   getCurrentAirportWeather,
   getPredictionWeather,
+  getPredictionWeatherByLocation,
 } from './weather';
 import { getSwellData } from './swell';
 
@@ -12,5 +13,6 @@ export {
   getCurrentCapitalWeatherData,
   getCurrentAirportWeather,
   getPredictionWeather,
+  getPredictionWeatherByLocation,
   getSwellData,
 };

--- a/services/cptec/weather.js
+++ b/services/cptec/weather.js
@@ -100,6 +100,32 @@ export const getCurrentAirportWeather = async (icaoCode) => {
 };
 
 /**
+ * Get weather predicion for the next 7 days with location based
+ * @param {float} lat
+ * @param {float} long
+ * @returns {object}
+ */
+export const getPredictionWeatherByLocation = async (lat, long) => {
+  const url = `${CPTEC_URL}/cidade/7dias/${lat}/${long}/previsaoLatLon.xml`;
+
+  const weatherPredictions = await axios.get(url, {
+    responseType: 'application/xml',
+    responseEncoding: 'binary',
+  });
+
+  const parsed = parser.parse(weatherPredictions.data);
+
+  if (parsed.cidade) {
+    const jsonData = formatPrediction(parsed);
+    if (jsonData.cidade === 'null') {
+      return null;
+    }
+    return jsonData;
+  }
+  return [];
+};
+
+/**
  * Get weather predicion for the next {days} with a limit of 14 days
  * @param {int} cityCode
  * @param {int} days

--- a/tests/cpetc/previsao-v1.test.js
+++ b/tests/cpetc/previsao-v1.test.js
@@ -87,4 +87,22 @@ describe('weather prediction v1 (E2E)', () => {
       }
     });
   });
+  describe('Route WITH lat long', () => {
+    test('GET /api/cptec/v1/clima/previsao/semana/:lat/:long', async () => {
+      const requestUrl = `${global.SERVER_URL}/api/cptec/v1/clima/previsao/semana/-22.90/-47.06`;
+      const response = await axios.get(requestUrl);
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.data)).toBe(false);
+
+      expect(Array.isArray(response.data.clima)).toBe(true);
+      expect(response.data.clima.length).toBeGreaterThan(2);
+      expect(response.data.clima.length).toBeLessThanOrEqual(7);
+
+      expect(response.data).toMatchObject({
+        cidade: 'Campinas',
+        estado: 'SP',
+      });
+    });
+  });
 });


### PR DESCRIPTION
I wanna create app weather without use city code only latitude and longitude, when I search in CPTEC API I found one endpoint with this resource so I add in here to facility use.

- add endpoint to get weather by location
- add test to weather location
- add doc of weather location API

Maybe some changes not in scope because `npm run fix` command.