### PR TITLE
add rejection to UF search promises when an empty list is returned

### DIFF
--- a/pages/api/ibge/municipios/v1/[uf].js
+++ b/pages/api/ibge/municipios/v1/[uf].js
@@ -9,13 +9,14 @@ import InternalError from '@/errors/InternalError';
 import BaseError from '@/errors/BaseError';
 
 import { getCities } from '@/services/dados-abertos-br/cities';
+import { rejectWhenEmptyArray } from '@/services/util/rejectWhenEmptyArray';
 
 const getData = async (uf, providers = null) => {
   const promises = [];
   if (!providers) {
-    promises.push(getContiesByUf(uf));
-    promises.push(getCities(uf));
-    promises.push(getStateCities(uf));
+    promises.push(rejectWhenEmptyArray(getContiesByUf(uf)));
+    promises.push(rejectWhenEmptyArray(getCities(uf)));
+    promises.push(rejectWhenEmptyArray(getStateCities(uf)));
   } else {
     if (providers.includes('wikipedia')) {
       promises.push(getStateCities(uf));

--- a/services/util/rejectWhenEmptyArray.js
+++ b/services/util/rejectWhenEmptyArray.js
@@ -1,0 +1,13 @@
+/**
+ * Rejects the promise if the data is an empty array.
+ *
+ * @param {Promise} promise
+ * @returns {Promise}
+ */
+export async function rejectWhenEmptyArray(promise) {
+  const data = await promise;
+  if (!data || data.length === 0) {
+    throw new Error('Empty data');
+  }
+  return data;
+}


### PR DESCRIPTION
## Issue Relacionada
#600 

## Causo do Erro
Quando é feita a chamada para o endpoint `/api/ibge/municipios/v1/AP` sem especificar um provedor, o service vai executar a chamada para os três provedores disponíveis, o que responder primeiro esse será o resultado da chamada ao endpoin.
Acontece que para alguns casos o primeiro provedor a responder retorna um lista vazia, ignorando os outros possíveis resultados validos dos outros providers

## Solução
Foi implementado a util function rejectWhenEmptyArray, que rejeita a promise quando o resultado da chama retorna uma lista vazia. Dessa forma os outros providers que responderem depois tmb serão considerados

## Teste local
Ao executar localmente é necessário adicionar um delay na função `getContiesByUf`
![image](https://github.com/BrasilAPI/BrasilAPI/assets/65142775/daab6891-c514-45ae-9666-84ef634a08dd)
