### PR TITLE
feat: adiciona open cep como fonte principal

### DIFF
--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -1,10 +1,7 @@
-import cep from 'cep-promise';
-
 import app from '@/app';
 import BadRequestError from '@/errors/BadRequestError';
 import NotFoundError from '@/errors/NotFoundError';
-
-const providers = ['correios', 'viacep', 'widenet', 'correios-alt'];
+import { fetchCep } from '@/services/cep/cep';
 
 const tempBlockedIps = [];
 
@@ -40,9 +37,7 @@ async function Cep(request, response) {
   try {
     const requestedCep = request.query.cep;
 
-    const cepResult = await cep(requestedCep, {
-      providers,
-    });
+    const cepResult = await fetchCep(requestedCep);
 
     response.status(200);
     return response.json(cepResult);
@@ -57,6 +52,10 @@ async function Cep(request, response) {
 
     if (error.type === 'service_error') {
       throw new NotFoundError(error);
+    }
+
+    if (error.type === 'bad_request') {
+      throw error;
     }
   }
 }

--- a/pages/api/cep/v2/[cep].js
+++ b/pages/api/cep/v2/[cep].js
@@ -1,16 +1,9 @@
-import cepPromise from 'cep-promise';
-
 import app from '@/app';
+import { fetchCep } from '@/services/cep/cep';
 import fetchGeocoordinateFromBrazilLocation from '../../../../lib/fetchGeocoordinateFromBrazilLocation';
-
-const providers = ['correios', 'viacep', 'widenet', 'correios-alt'];
 
 const CACHE_CONTROL_HEADER_VALUE =
   'max-age=0, s-maxage=86400, stale-while-revalidate, public';
-
-async function getCepFromCepPromise(requestedCep) {
-  return cepPromise(requestedCep, { providers });
-}
 
 async function Cep(request, response) {
   const requestedCep = request.query.cep;
@@ -18,7 +11,7 @@ async function Cep(request, response) {
   response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
 
   try {
-    const cepFromCepPromise = await getCepFromCepPromise(requestedCep);
+    const cepFromCepPromise = await fetchCep(requestedCep);
     const location = await fetchGeocoordinateFromBrazilLocation(
       cepFromCepPromise
     );
@@ -48,6 +41,8 @@ async function Cep(request, response) {
 
       response.json(error);
       return;
+    } else if (error.type === 'bad_request') {
+      throw error;
     }
 
     response.status(500);

--- a/pages/docs/doc/cep.json
+++ b/pages/docs/doc/cep.json
@@ -15,7 +15,7 @@
             "get": {
                 "tags": ["CEP"],
                 "summary": "Busca por CEP com múltiplos providers de fallback.",
-                "description": "",
+                "description": "A busca utiliza como fonte principal o OpenCep, caso não encontre o CEP é buscado em diversos outros providers de CEP.",
                 "parameters": [
                     {
                         "name": "cep",

--- a/services/cep/cep.js
+++ b/services/cep/cep.js
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import cepPromise from 'cep-promise';
+
+const providers = ['correios', 'viacep', 'widenet', 'correios-alt'];
+
+const CEP_LENGTH = 8;
+const DEFAULT_TIMEOUT = 3 * 1000;
+
+function onlyDigits(cep) {
+  return cep.replace(/\D/g, '');
+}
+
+function isValidCep(cep) {
+  const cleanCep = onlyDigits(cep);
+  return cleanCep.length === CEP_LENGTH;
+}
+
+async function fetchOpenCep(cep) {
+  const { data } = await axios.get(`https://opencep.com/v1/${cep}`, {
+    timeout: DEFAULT_TIMEOUT,
+  });
+
+  return {
+    cep: onlyDigits(data.cep),
+    state: data.uf,
+    city: data.localidade,
+    neighborhood: data.bairro,
+    street: data.logradouro,
+    service: 'open-cep',
+  };
+}
+
+class CepPromiseError extends Error {
+  constructor({ message, type, errors } = {}) {
+    super();
+
+    this.name = 'CepPromiseError';
+    this.message = message;
+    this.type = type;
+    this.errors = errors;
+  }
+}
+
+export async function fetchCep(cep) {
+  if (!isValidCep(cep)) {
+    throw new CepPromiseError({
+      message: `CEP deve conter exatamente ${CEP_LENGTH} caracteres.`,
+      type: 'validation_error',
+      errors: [
+        {
+          message: `CEP informado possui mais do que ${CEP_LENGTH} caracteres.`,
+          service: 'cep_validation',
+        },
+      ],
+    });
+  }
+
+  const cleanCep = onlyDigits(cep);
+
+  const fetchCepPromise = () =>
+    cepPromise(cleanCep, {
+      providers,
+    });
+
+  return fetchOpenCep(cleanCep).catch(fetchCepPromise);
+}

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -15,6 +15,20 @@ describe('/cep/v1 (E2E)', () => {
     });
   });
 
+  test('Verifica fonte da informação: 05010000', async () => {
+    const requestUrl = `${global.SERVER_URL}/api/cep/v1/05010000`;
+    const response = await axios.get(requestUrl);
+
+    expect(response.data).toEqual({
+      cep: '05010000',
+      state: 'SP',
+      city: 'São Paulo',
+      neighborhood: 'Perdizes',
+      street: 'Rua Caiubi',
+      service: 'open-cep',
+    });
+  });
+
   test('Utilizando um CEP inexistente: 00000000', async () => {
     expect.assertions(2);
     const requestUrl = `${global.SERVER_URL}/api/cep/v1/00000000`;

--- a/tests/cep-v2.test.js
+++ b/tests/cep-v2.test.js
@@ -22,6 +22,27 @@ describe('/cep/v2 (E2E)', () => {
     });
   });
 
+  test('Verifica fonte da informação: 05010000', async () => {
+    const requestUrl = `${global.SERVER_URL}/api/cep/v2/05010000`;
+    const response = await axios.get(requestUrl);
+
+    expect(response.data).toEqual({
+      cep: '05010000',
+      state: 'SP',
+      city: 'São Paulo',
+      neighborhood: 'Perdizes',
+      street: 'Rua Caiubi',
+      service: 'open-cep',
+      location: {
+        type: 'Point',
+        coordinates: {
+          longitude: expect.any(String),
+          latitude: expect.any(String),
+        },
+      },
+    });
+  });
+
   test('Utilizando um CEP inexistente: 00000000', async () => {
     expect.assertions(2);
     const requestUrl = `${global.SERVER_URL}/api/cep/v2/00000000`;


### PR DESCRIPTION
Modifica a consulta de cep para priorizar dados vindos do open cep e assim evitar a consulta excessiva nos outros provedores.

Obs: localmente os testes estavam funcionando, pode ser algum bloqueio de IP

![image](https://github.com/BrasilAPI/BrasilAPI/assets/16273730/316ca4f2-3e09-4727-bf17-8a3f1f26e8d7)
![image](https://github.com/BrasilAPI/BrasilAPI/assets/16273730/4ac1d052-0e2e-4348-9d20-30613d49527f)

