### PR TITLE
Upgrade next_connect do version 0.12.1

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ import firewall from './middlewares/firewall';
 
 const corsDefaultConfiguration = {
   origin: '*',
-  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE, OPTIONS',
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
   preflightContinue: false,
   optionsSuccessStatus: 204,
 };

--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ import firewall from './middlewares/firewall';
 
 const corsDefaultConfiguration = {
   origin: '*',
-  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE, OPTIONS',
   preflightContinue: false,
   optionsSuccessStatus: 204,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "micro-cors": "0.1.1",
         "mobx": "6.7.0",
         "next": "12.3.4",
-        "next-connect": "^0.12.1",
+        "next-connect": "0.12.1",
         "next-sitemap": "1.6.168",
         "papaparse": "5.4.0",
         "piscina": "3.2.0",
@@ -10752,9 +10752,9 @@
       }
     },
     "node_modules/next-connect": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.12.2.tgz",
-      "integrity": "sha512-B/zKHPs5S7XWvAVsZVLvOeY2eL2U3g0W/BgCDetEJRcNDzxX2vi8rzqBuEoLLPlI8LvtHwujDVUFFjSgOEZTbA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.12.1.tgz",
+      "integrity": "sha512-pzW3oKCYAaNOxQncIIv53cHrRaZSeQ2KZ9chjYx/OHgASV8qDNlVvD3Mz9RTrO9TuJs3kjt0VeTBGJmoE/yl2g==",
       "dependencies": {
         "trouter": "^3.2.0"
       }
@@ -21889,9 +21889,9 @@
       }
     },
     "next-connect": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.12.2.tgz",
-      "integrity": "sha512-B/zKHPs5S7XWvAVsZVLvOeY2eL2U3g0W/BgCDetEJRcNDzxX2vi8rzqBuEoLLPlI8LvtHwujDVUFFjSgOEZTbA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.12.1.tgz",
+      "integrity": "sha512-pzW3oKCYAaNOxQncIIv53cHrRaZSeQ2KZ9chjYx/OHgASV8qDNlVvD3Mz9RTrO9TuJs3kjt0VeTBGJmoE/yl2g==",
       "requires": {
         "trouter": "^3.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "micro-cors": "0.1.1",
         "mobx": "6.7.0",
         "next": "12.3.4",
-        "next-connect": "0.9.1",
+        "next-connect": "^0.12.1",
         "next-sitemap": "1.6.168",
         "papaparse": "5.4.0",
         "piscina": "3.2.0",
@@ -10752,11 +10752,11 @@
       }
     },
     "node_modules/next-connect": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.9.1.tgz",
-      "integrity": "sha512-CPEdciM43y9oHKxE/KVtlB+vbWwTCYqPr8/EjzoMtSRIi0s7XhdSrY6VShlACnnsJzsAr/RZnL3/xFC/vjgZUQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.12.2.tgz",
+      "integrity": "sha512-B/zKHPs5S7XWvAVsZVLvOeY2eL2U3g0W/BgCDetEJRcNDzxX2vi8rzqBuEoLLPlI8LvtHwujDVUFFjSgOEZTbA==",
       "dependencies": {
-        "trouter": "^3.1.0"
+        "trouter": "^3.2.0"
       }
     },
     "node_modules/next-sitemap": {
@@ -21889,11 +21889,11 @@
       }
     },
     "next-connect": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.9.1.tgz",
-      "integrity": "sha512-CPEdciM43y9oHKxE/KVtlB+vbWwTCYqPr8/EjzoMtSRIi0s7XhdSrY6VShlACnnsJzsAr/RZnL3/xFC/vjgZUQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-0.12.2.tgz",
+      "integrity": "sha512-B/zKHPs5S7XWvAVsZVLvOeY2eL2U3g0W/BgCDetEJRcNDzxX2vi8rzqBuEoLLPlI8LvtHwujDVUFFjSgOEZTbA==",
       "requires": {
-        "trouter": "^3.1.0"
+        "trouter": "^3.2.0"
       }
     },
     "next-sitemap": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "micro-cors": "0.1.1",
     "mobx": "6.7.0",
     "next": "12.3.4",
-    "next-connect": "0.9.1",
+    "next-connect": "^0.12.1",
     "next-sitemap": "1.6.168",
     "papaparse": "5.4.0",
     "piscina": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "micro-cors": "0.1.1",
     "mobx": "6.7.0",
     "next": "12.3.4",
-    "next-connect": "^0.12.1",
+    "next-connect": "0.12.1",
     "next-sitemap": "1.6.168",
     "papaparse": "5.4.0",
     "piscina": "3.2.0",


### PR DESCRIPTION
A versão 13.0.0 incluiu um comportamento que faz o next-connect retornar 404 sempre que todos os handlers da rota forem somente middlewares, o que fez nosso cors quebrar, visto que o options é tratado no middleware.

Commit relacionado: https://github.com/hoangvvo/next-connect/commit/edc99ddb7531dd399294158063cbfb2eb4fbe80d