### PR TITLE
doc: Conserta a especificação Swagger/OpenAPI para ser usada com ferramentas de converção em código

### DIFF
--- a/pages/docs/doc/ddd.json
+++ b/pages/docs/doc/ddd.json
@@ -80,7 +80,9 @@
                     },
                     "cities": {
                         "type": "array",
-                        "items": "string"
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "nome": {
                         "type": "string"

--- a/pages/docs/doc/ibge.json
+++ b/pages/docs/doc/ibge.json
@@ -6,7 +6,7 @@
         }
     ],
     "paths": {
-        "/ibge/municipios/v1/{siglaUF}?providers=dados-abertos-br,gov,wikipedia": {
+        "/ibge/municipios/v1/{siglaUF}": {
             "get": {
               "tags": [
                 "IBGE"


### PR DESCRIPTION
## Descrição
> **[...]/doc/ddd.json:** Conserta o tipo esperado "items" de "cities" para ser um objeto e não uma string
> **[...]/doc/ibge.json:** Remove os parâmetros de "providers" da URL do path do endpoint, já que isso não segue o padrão OpenAPI 3.1.0

Correções testadas com as ferramentas [@hey-api/openapi-ts](https://www.npmjs.com/package/@hey-api/openapi-ts) e [openapi-typescript](https://www.npmjs.com/package/openapi-typescript).