### PR TITLE
feat: adicionada resposta de erro para os serviços de CEP que retorna…

### DIFF
--- a/pages/docs/doc/cep.json
+++ b/pages/docs/doc/cep.json
@@ -92,6 +92,16 @@
                                 }
                             }
                         }
+                    },
+                    "504": {
+                        "description": "Todos os serviços de CEP retornaram erro.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CepError"
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#649
O problema não é na API em sí, pesquisei manualmente em todos os sistemas de busca de CEP que o sistema utiliza e nenhum deles conseguiu retornar dados para o CEP em questão da Issue. Logo, entendi que o problema é a tela de Time Out.
Acredito que apenas incluir uma mensagem de erro para o código 504 deva bastar.