### PR TITLE
feat: get business days (Retorna todos os dias úteis entre duas datas)

### DIFF
--- a/pages/api/diasuteis/v1/[diasuteis].js
+++ b/pages/api/diasuteis/v1/[diasuteis].js
@@ -25,7 +25,7 @@ const diasUteisHandler = (request, response) => {
 
     // para caso tenha mais de um ano entre as datas
     const anos = [];
-    for (let ano = inicio.getFullYear(); ano <= fim.getFullYear(); ano = ano + 1) {
+    for (let ano = inicio.getFullYear(); ano <= fim.getFullYear(); ano += 1) {
       anos.push(ano);
     }
 

--- a/pages/api/diasuteis/v1/[diasuteis].js
+++ b/pages/api/diasuteis/v1/[diasuteis].js
@@ -1,0 +1,62 @@
+import app from "@/app";
+import BaseError from "@/errors/BaseError";
+import InternalError from "@/errors/InternalError";
+import getHolidays from "@/services/holidays";
+
+const diasUteisHandler = (request, response) => {
+  const {
+    dataInicial = "",
+    dataFinal = "",
+    incluirFeriadosNacionais = "true",
+    feriadosEstaduais = [],   // TODO: usar futuramente para considerar feriados estaduais
+    feriadosMunicipais = [],  // TODO: usar futuramente para considerar feriados municipais
+  } = request.query;
+
+  try {
+    if (!dataInicial || !dataFinal) {
+      return response.status(400).json({
+        message: "Parâmetros dataInicial e dataFinal são obrigatórios",
+        type: "DATE_PARAM_MISSING",
+      });
+    }
+  
+    const inicio = new Date(dataInicial);
+    const fim = new Date(dataFinal);
+  
+    // para caso tenha mais de um ano entre as datas
+    const anos = [];
+    for (let ano = inicio.getFullYear(); ano <= fim.getFullYear(); ano++) {
+      anos.push(ano);
+    }
+  
+    const feriados = incluirFeriadosNacionais === "true" ?
+      anos.flatMap(getHolidays) : [];
+  
+    const diasUteis = [];
+  
+    for (let data = new Date(inicio); data <= fim; data.setDate(data.getDate() + 1)) {
+      const dia = data.getDay();
+      const dataString = data.toISOString().split("T")[0];
+      const isFeriado = feriados.some(feriado => feriado.date === dataString);
+
+      // segunda-feira é index 0
+      const isDiaUtil = dia !== 5 && dia !== 6;
+  
+      if (isDiaUtil && !isFeriado) diasUteis.push(dataString);
+    }
+
+    return response.status(200).json({ diasUteis });
+
+  } catch(error) {
+    if (error instanceof BaseError) {
+      throw error;
+    }
+
+    throw new InternalError({
+      message: "Erro ao buscar dias úteis",
+      type: "business_days_error"
+    })
+  }
+};
+
+export default app().get(diasUteisHandler);

--- a/pages/api/diasuteis/v1/[diasuteis].js
+++ b/pages/api/diasuteis/v1/[diasuteis].js
@@ -1,61 +1,64 @@
-import app from "@/app";
-import BaseError from "@/errors/BaseError";
-import InternalError from "@/errors/InternalError";
-import getHolidays from "@/services/holidays";
+import app from '@/app';
+import BaseError from '@/errors/BaseError';
+import InternalError from '@/errors/InternalError';
+import getHolidays from '@/services/holidays';
 
 const diasUteisHandler = (request, response) => {
   const {
-    dataInicial = "",
-    dataFinal = "",
-    incluirFeriadosNacionais = "true",
-    feriadosEstaduais = [],   // TODO: usar futuramente para considerar feriados estaduais
-    feriadosMunicipais = [],  // TODO: usar futuramente para considerar feriados municipais
+    dataInicial = '',
+    dataFinal = '',
+    incluirFeriadosNacionais = 'true',
+    // feriadosEstaduais = [], TODO: usar futuramente para considerar feriados estaduais
+    // feriadosMunicipais = [], TODO: usar futuramente para considerar feriados municipais
   } = request.query;
 
   try {
     if (!dataInicial || !dataFinal) {
       return response.status(400).json({
-        message: "Parâmetros dataInicial e dataFinal são obrigatórios",
-        type: "DATE_PARAM_MISSING",
+        message: 'Parâmetros dataInicial e dataFinal são obrigatórios',
+        type: 'DATE_PARAM_MISSING',
       });
     }
-  
+
     const inicio = new Date(dataInicial);
     const fim = new Date(dataFinal);
-  
+
     // para caso tenha mais de um ano entre as datas
     const anos = [];
     for (let ano = inicio.getFullYear(); ano <= fim.getFullYear(); ano++) {
       anos.push(ano);
     }
-  
-    const feriados = incluirFeriadosNacionais === "true" ?
-      anos.flatMap(getHolidays) : [];
-  
+
+    const feriados =
+      incluirFeriadosNacionais === 'true' ? anos.flatMap(getHolidays) : [];
+
     const diasUteis = [];
-  
-    for (let data = new Date(inicio); data <= fim; data.setDate(data.getDate() + 1)) {
+
+    for (
+      let data = new Date(inicio);
+      data <= fim;
+      data.setDate(data.getDate() + 1)
+    ) {
       const dia = data.getDay();
-      const dataString = data.toISOString().split("T")[0];
-      const isFeriado = feriados.some(feriado => feriado.date === dataString);
+      const dataString = data.toISOString().split('T')[0];
+      const isFeriado = feriados.some((feriado) => feriado.date === dataString);
 
       // segunda-feira é index 0
       const isDiaUtil = dia !== 5 && dia !== 6;
-  
+
       if (isDiaUtil && !isFeriado) diasUteis.push(dataString);
     }
 
     return response.status(200).json({ diasUteis });
-
-  } catch(error) {
+  } catch (error) {
     if (error instanceof BaseError) {
       throw error;
     }
 
     throw new InternalError({
-      message: "Erro ao buscar dias úteis",
-      type: "business_days_error"
-    })
+      message: 'Erro ao buscar dias úteis',
+      type: 'business_days_error',
+    });
   }
 };
 

--- a/pages/api/diasuteis/v1/[diasuteis].js
+++ b/pages/api/diasuteis/v1/[diasuteis].js
@@ -25,7 +25,7 @@ const diasUteisHandler = (request, response) => {
 
     // para caso tenha mais de um ano entre as datas
     const anos = [];
-    for (let ano = inicio.getFullYear(); ano <= fim.getFullYear(); ano++) {
+    for (let ano = inicio.getFullYear(); ano <= fim.getFullYear(); ano = ano + 1) {
       anos.push(ano);
     }
 

--- a/pages/docs/doc/diasuteis.json
+++ b/pages/docs/doc/diasuteis.json
@@ -8,9 +8,7 @@
   "paths": {
     "/diasuteis/v1/{diasuteis}": {
       "get": {
-        "tags": [
-          "Dias Úteis"
-        ],
+        "tags": ["Dias Úteis"],
         "summary": "Busca todos os dias úteis entre duas datas",
         "description": "Retorna todos os dias úteis entre `dataInicial` e `dataFinal`, considerando ou não os feriados nacionais.",
         "parameters": [
@@ -83,11 +81,7 @@
           }
         },
         "example": {
-          "diasUteis": [
-            "2025-01-02",
-            "2025-01-03",
-            "2025-01-06"
-          ]
+          "diasUteis": ["2025-01-02", "2025-01-03", "2025-01-06"]
         }
       },
       "ErrorMessage": {

--- a/pages/docs/doc/diasuteis.json
+++ b/pages/docs/doc/diasuteis.json
@@ -1,0 +1,110 @@
+{
+  "tags": [
+    {
+      "name": "Dias Úteis",
+      "description": "Busca de dias úteis com base em um intervalo de datas."
+    }
+  ],
+  "paths": {
+    "/diasuteis/v1/{diasuteis}": {
+      "get": {
+        "tags": [
+          "Dias Úteis"
+        ],
+        "summary": "Busca todos os dias úteis entre duas datas",
+        "description": "Retorna todos os dias úteis entre `dataInicial` e `dataFinal`, considerando ou não os feriados nacionais.",
+        "parameters": [
+          {
+            "name": "dataInicial",
+            "description": "Data inicial no formato YYYY-MM-DD",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "dataFinal",
+            "description": "Data final no formato YYYY-MM-DD",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "incluirFeriadosNacionais",
+            "description": "Define se os feriados nacionais devem ser considerados. Aceita 'true' ou 'false'.",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dias úteis retornados com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiasUteisResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Parâmetro(s) ausente(s) ou inválido(s)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DiasUteisResponse": {
+        "type": "object",
+        "properties": {
+          "diasUteis": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        },
+        "example": {
+          "diasUteis": [
+            "2025-01-02",
+            "2025-01-03",
+            "2025-01-06"
+          ]
+        }
+      },
+      "ErrorMessage": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "message": "Parâmetros dataInicial e dataFinal são obrigatórios",
+          "type": "DATE_PARAM_MISSING"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Novo endpoint: Dias Úteis  

Fechando a #678, este PR adiciona um novo endpoint para retornar os dias úteis entre duas datas, considerando os feriados nacionais disponíveis na API `feriados/v1`.

### Parâmetros suportados:
- `dataInicial` (obrigatório) — ex: `2025-01-01`
- `dataFinal` (obrigatório) — ex: `2025-01-31`
- `incluirFeriadosNacionais` (opcional, padrão `true`)
- `feriadosEstaduais` (não implementado ainda — **TODO**)
- `feriadosMunicipais` (não implementado ainda — **TODO**)

### Exemplo de resposta:
```json
{
  "diasUteis": [
    "2025-01-02",
    "2025-01-03",
    "..."
  ]
}
````
Fico feliz em poder contribuir com a BrasilAPI!