### PR TITLE
feat: implementing ibge city code + state in cep json payload (Implementando informações ao objeto de CEP)

### DIFF
--- a/services/cep/cep.js
+++ b/services/cep/cep.js
@@ -15,10 +15,18 @@ function isValidCep(cep) {
   return cleanCep.length === CEP_LENGTH;
 }
 
+function extractIbgeInfo(ibge) {
+  const code = String(ibge || '');
+  const state = code.slice(0, 2) || null;
+  return { code, state };
+}
+
 async function fetchOpenCep(cep) {
   const { data } = await axios.get(`https://opencep.com/v1/${cep}`, {
     timeout: DEFAULT_TIMEOUT,
   });
+
+  const { code, state } = extractIbgeInfo(data.ibge);
 
   return {
     cep: onlyDigits(data.cep),
@@ -27,6 +35,10 @@ async function fetchOpenCep(cep) {
     neighborhood: data.bairro,
     street: data.logradouro,
     service: 'open-cep',
+    ibge: {
+      code,
+      state,
+    },
   };
 }
 

--- a/services/cep/cep.js
+++ b/services/cep/cep.js
@@ -16,9 +16,9 @@ function isValidCep(cep) {
 }
 
 function extractIbgeInfo(ibge) {
-  const code = String(ibge || '');
-  const state = code.slice(0, 2) || null;
-  return { code, state };
+  const city = String(ibge || '');
+  const state = city.slice(0, 2) || null;
+  return { city, state };
 }
 
 async function fetchOpenCep(cep) {
@@ -26,7 +26,7 @@ async function fetchOpenCep(cep) {
     timeout: DEFAULT_TIMEOUT,
   });
 
-  const { code, state } = extractIbgeInfo(data.ibge);
+  const { city, state } = extractIbgeInfo(data.ibge);
 
   return {
     cep: onlyDigits(data.cep),
@@ -36,7 +36,7 @@ async function fetchOpenCep(cep) {
     street: data.logradouro,
     service: 'open-cep',
     ibge: {
-      code,
+      city,
       state,
     },
   };


### PR DESCRIPTION
## ✨ Closes #685: Adiciona código IBGE do município e do estado ao retorno dos endpoints de CEP

Este PR inclui no payload dos endpoints `v1` e `v2` de CEP os seguintes dados adicionais:

- `ibge.city`: código IBGE do município
- `ibge.state`: código IBGE da unidade federativa (UF)

Essas informações são especialmente úteis para sistemas que realizam cadastros com base em códigos oficiais do IBGE.

###  Exemplo de resposta

```json
{
  "cep": "39404006",
  "state": "MG",
  "city": "Montes Claros",
  "neighborhood": "Conjunto Residencial JK",
  "street": "Avenida Osmani Barbosa",
  "service": "open-cep",
  "ibge": {
    "city": "3143302",
    "state": "31"
  },
  "location": {
    "type": "Point",
    "coordinates": {}
  }
}
```

Fico feliz em poder contribuir com a BrasilAPI! 

