### PR TITLE
fix(banks): filter out empty CSV rows that returned invalid bank entries

### DIFF
--- a/services/banco-central/index.js
+++ b/services/banco-central/index.js
@@ -6,7 +6,9 @@ const formatCsvFile = (file) => {
   // Remove o cabeçalho
   file.shift();
 
-  return file.map(
+  return file
+    .filter(([ispb, name, code]) => ispb && code)
+    .map(
     ([
       ispb, // ISPB
       name, // Nome_Reduzido


### PR DESCRIPTION
O CSV fornecido pela API do Banco Central inclui duas linhas vazias no final 
do arquivo. Essas linhas estavam sendo interpretadas como entradas válidas, 
gerando objetos como:

    {
        "ispb": "",
        "code": null
    }

Isso fazia com que dados inválidos aparecessem no conjunto de bancos.

Alterações introduzidas:
- Adicionado um filtro para ignorar linhas onde `ispb` ou `code` estão vazios.
- Garantido que a etapa de mapeamento só retorne valores válidos, sem espaços 
  e corretamente formatados.
- Impedido que consumidores da função `getBanksData` recebam entradas 
  malformadas.

Impacto:
- A API não retornará mais bancos vazios com códigos nulos.
- A consistência dos dados foi aprimorada para consumidores que dependem da 
  lista de bancos.
- O fallback para o arquivo local `banksList.json` permanece inalterado caso 
  a requisição do CSV falhe.

Closes #683