### PR TITLE
Add Timezone name to CEP v2

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -62,24 +62,29 @@ async function fetchGeocoordinateFromBrazilLocation({
   }
 
   const jsonData = await response.json();
+  let location;
 
-  const jsonDataWithPostCodes = jsonData.filter(
-    (item) => item.address.postcode
-  );
+  if (cep) {
+    const jsonDataWithPostCodes = jsonData.filter(
+      (item) => item.address.postcode
+    );
 
-  const cleanedCep = cep.replace(/\D/g, '');
+    const cleanedCep = cep.replace(/\D/g, '');
 
-  const exactLocation = jsonDataWithPostCodes.find(
-    (item) => item.address.postcode.replace(/\D/g, '') === cleanedCep
-  );
+    const exactLocation = jsonDataWithPostCodes.find(
+      (item) => item.address.postcode.replace(/\D/g, '') === cleanedCep
+    );
 
-  const approximateLocation = jsonDataWithPostCodes.find(
-    (item) =>
-      item.address.postcode.replace(/\D/g, '').slice(0, 5) ===
-      cleanedCep.slice(0, 5)
-  );
+    const approximateLocation = jsonDataWithPostCodes.find(
+      (item) =>
+        item.address.postcode.replace(/\D/g, '').slice(0, 5) ===
+        cleanedCep.slice(0, 5)
+    );
 
-  const location = exactLocation || approximateLocation;
+    location = exactLocation || approximateLocation;
+  } else {
+    [location] = jsonData;
+  }
 
   if (!location) {
     return unavailableCoordinate;

--- a/lib/fetchTimezoneNameFromBrazilLocation.js
+++ b/lib/fetchTimezoneNameFromBrazilLocation.js
@@ -1,0 +1,30 @@
+import tzlookup from 'tz-lookup';
+import fetchGeocoordinateFromBrazilLocation from './fetchGeocoordinateFromBrazilLocation';
+
+async function fetchTimezoneNameFromBrazilLocation({
+  coordinates,
+  state,
+  city,
+}) {
+  if (coordinates?.latitude && coordinates?.longitude) {
+    return tzlookup(coordinates.latitude, coordinates.longitude);
+  }
+
+  if (state && city) {
+    const location = await fetchGeocoordinateFromBrazilLocation({
+      state,
+      city,
+    });
+
+    if (location?.coordinates?.latitude && location?.coordinates?.longitude) {
+      return tzlookup(
+        location.coordinates.latitude,
+        location.coordinates.longitude
+      );
+    }
+  }
+
+  return null;
+}
+
+export default fetchTimezoneNameFromBrazilLocation;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "sass": "1.56.1",
         "selic": "1.1.0",
         "styled-components": "5.3.6",
+        "tz-lookup": "^6.1.25",
         "vite": "6.2.2",
         "wikijs": "6.4.0"
       },
@@ -9925,6 +9926,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg=="
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sass": "1.56.1",
     "selic": "1.1.0",
     "styled-components": "5.3.6",
+    "tz-lookup": "^6.1.25",
     "vite": "6.2.2",
     "wikijs": "6.4.0"
   },

--- a/pages/api/cep/v2/[cep].js
+++ b/pages/api/cep/v2/[cep].js
@@ -1,6 +1,7 @@
 import app from '@/app';
 import { fetchCep } from '@/services/cep/cep';
 import fetchGeocoordinateFromBrazilLocation from '../../../../lib/fetchGeocoordinateFromBrazilLocation';
+import fetchTimezoneNameFromBrazilLocation from '../../../../lib/fetchTimezoneNameFromBrazilLocation';
 
 const CACHE_CONTROL_HEADER_VALUE =
   'max-age=0, s-maxage=86400, stale-while-revalidate, public';
@@ -16,6 +17,11 @@ async function getCepWithLocation(request, response) {
       cepFromCepPromise
     );
 
+    const timezoneName = await fetchTimezoneNameFromBrazilLocation({
+      ...location,
+      ...cepFromCepPromise,
+    });
+
     if (!cepFromCepPromise.street) {
       cepFromCepPromise.street = null;
     }
@@ -25,7 +31,7 @@ async function getCepWithLocation(request, response) {
     }
 
     response.status(200);
-    response.json({ ...cepFromCepPromise, location });
+    response.json({ ...cepFromCepPromise, timezoneName, location });
   } catch (error) {
     if (error.name === 'CepPromiseError') {
       switch (error.type) {

--- a/pages/docs/doc/cep.json
+++ b/pages/docs/doc/cep.json
@@ -193,6 +193,7 @@
                     "city",
                     "neighborhood",
                     "street",
+                    "timezoneName",
                     "location"
                 ],
                 "type": "object",
@@ -219,6 +220,11 @@
                         "nullable": true,
                         "description": "Nome da rua/logradouro (pode ser nulo)"
                     },
+                    "timezoneName": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Nome da timezone do local (pode ser nulo)"
+                    },
                     "location": {
                         "type": "object",
                         "$ref": "#/components/schemas/Location",
@@ -231,6 +237,7 @@
                     "city": "Blumenau",
                     "neighborhood": "Centro",
                     "street": "Rua Doutor Luiz de Freitas Melro",
+                    "timezoneName": "America/Sao_Paulo",
                     "location": {
                         "type": "Point",
                         "coordinates": {

--- a/tests/cep-v2.test.js
+++ b/tests/cep-v2.test.js
@@ -22,6 +22,7 @@ describe('/cep/v2 (E2E)', () => {
       neighborhood: 'Perdizes',
       street: 'Rua Caiubi',
       service: expect.any(String),
+      timezoneName: 'America/Sao_Paulo',
       location: {
         type: 'Point',
         coordinates: {
@@ -43,6 +44,7 @@ describe('/cep/v2 (E2E)', () => {
       neighborhood: 'Perdizes',
       street: 'Rua Caiubi',
       service: 'open-cep',
+      timezoneName: 'America/Sao_Paulo',
       location: {
         type: 'Point',
         coordinates: {
@@ -106,6 +108,7 @@ describe('/cep/v2 (E2E)', () => {
       neighborhood: 'Piedade',
       street: 'Rua Marcolino',
       service: expect.any(String),
+      timezoneName: 'America/Sao_Paulo',
       location: {
         type: 'Point',
         coordinates: {
@@ -127,6 +130,7 @@ describe('/cep/v2 (E2E)', () => {
       neighborhood: null,
       street: null,
       service: expect.any(String),
+      timezoneName: 'America/Sao_Paulo',
       location: {
         type: 'Point',
         coordinates: {


### PR DESCRIPTION
Add nome da timezone na resposta da consulta de um CEP. 

No Brasil temos 4 zonas de tempo e essa informação é fundamental para exibição correta de horários de eventos em sistemas que abrangem todo o território nacional ou pelo menos alguns estados que utilizam de time zones diferentes.

Embora sejam 4 offsets distintos (-2, -3, -4 e -5), existem diversos nomes de timezones para cada offset, para as principais cidades brasileiras. Isso se dá devido à utilização de horário de verão em algumas regiões que, atualmente, quando aplicado, o horário de verão compreende apenas o offset -3, porém não todo ele. Então regiões da timezone `America/Sao_Paulo`, por exemplo, sofrem influência da mudança de horário (assumindo offset -2 temporariamente), enquanto em regiões que utilizam, por exemplo, `America/Fortaleza`, embora participantes do mesmo offset -3, não alteram o horário, permanecendo -3. Por isso é importante trabalhar com o nome da TZ, que é fixo, ao invés do offset que pode variar.

O endpoint /cep/v2 já busca coordenadas do cep, que é agora utilizada pra encontrar a timezone. Para casos onde o cep não retorne coordenadas, o que pode ser devido ao cep ser novo ou a uma rua que tenha outros nomes e outros ceps, fazemos a busca pelas coordenadas da cidade a fim de buscar a timezone com base nessas coordenadas. Pra fins de TZ nada muda uma vez que em uma mesma cidade a TZ é sempre a mesma independentemente do bairro ou rua.