### PR TITLE
fix(cptec): add validation for integer days in swell predictions

### DIFF
--- a/pages/api/cptec/v1/ondas/[cityCode]/[days].js
+++ b/pages/api/cptec/v1/ondas/[cityCode]/[days].js
@@ -9,17 +9,17 @@ import { MAX_SWELL_DAYS, MIN_DAYS } from '@/services/cptec/constants';
 async function getSwellPredictions(request, response) {
   const { days, cityCode } = request.query;
 
-  if (!Number.isInteger(Number(days))) {
+  if (!Number.isFinite(Number(days))) {
     throw new BadRequestError({
-      message: 'Quantidade de dias inválida, informe um valor inteiro',
+      message: 'Quantidade de dias inválida, informe um valor numérico',
       type: 'request_error',
       name: 'INVALID_NUMBER_OF_DAYS',
     });
   }
 
-  if (!Number.isFinite(Number(days))) {
+  if (!Number.isInteger(Number(days))) {
     throw new BadRequestError({
-      message: 'Quantidade de dias inválida, informe um valor numérico',
+      message: 'Quantidade de dias inválida, informe um valor inteiro',
       type: 'request_error',
       name: 'INVALID_NUMBER_OF_DAYS',
     });

--- a/tests/cpetc/ondas-v1.test.js
+++ b/tests/cpetc/ondas-v1.test.js
@@ -124,5 +124,22 @@ describeIf(shouldSkipTests)('ondas prediction v1 (E2E)', () => {
         });
       }
     });
+
+    test('GET /api/cptec/v1/ondas/:cityCode/:days (Non-integer days: 1.5)', async () => {
+      const requestUrl = `${global.SERVER_URL}/api/cptec/v1/ondas/241/1.5`;
+
+      try {
+        await axios.get(requestUrl);
+      } catch (error) {
+        const { response } = error;
+
+        expect(response.status).toBe(400);
+        expect(response.data).toMatchObject({
+          message: 'Quantidade de dias inválida, informe um valor inteiro',
+          type: 'request_error',
+          name: 'INVALID_NUMBER_OF_DAYS',
+        });
+      }
+    });
   });
 });


### PR DESCRIPTION
## Descrição

De acordo com a documentação a API de previsão de ondas do CPTEC o parâmetro `days` deveria aceitar somente números interiro  (int32) , contudo estava aceitando valores decimais.

**Exemplo de request com problema:**
```
GET /api/cptec/v1/ondas/241/3.5
```

## Solução implementada

- Adicionada validação, usando `Number.isInteger()`, para garantir que o parâmetro `days` seja um número inteiro
- Retorno de erro `400 Bad Request` com mensagem descritiva quando valores decimais são fornecidos
- Preservação do comportamento existente para valores válidos

## Teste

`GET http://localhost:3000/api/cptec/v1/ondas/4757/3.5`

<img width="1231" height="414" alt="image" src="https://github.com/user-attachments/assets/b41b783d-c495-461e-a3ef-3086c59a6d7c" />

Fixes #713 