### PR TITLE
Adiciona novos testes MC/DC para o método isValidIsbn()

### DIFF
--- a/tests/isbn-tools.test.js
+++ b/tests/isbn-tools.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+
+import { isValidIsbn } from '../services/isbn/tools';
+
+describe('isValidIsbn()', () => {
+  it('CT1 — Tamanho inválido (11 dígitos) → false', () => {
+    const isbn = '12345678901'; // 11 dígitos
+    expect(isValidIsbn(isbn)).toBe(false);
+  });
+
+  it('CT2 — Tamanho válido (ISBN-10) e dentro do padrão → true', () => {
+    const isbn = '8535902775'
+    expect(isValidIsbn(isbn)).toBe(true);
+  });
+
+  it('CT3 — Tamanho válido (ISBN-13) e dentro do padrão → true', () => {
+    const isbn = '9788571537415'; 
+    expect(isValidIsbn(isbn)).toBe(true);
+  });
+
+  it('CT4 — Fora do padrão ISBN (formato aceito, mas regex rejeita) → false', () => {
+    const isbn = '2222222222';
+    expect(isValidIsbn(isbn)).toBe(false);
+  });
+});


### PR DESCRIPTION
# [Tests] Adiciona testes para `isValidIsbn`

## Resumo
Este PR adiciona testes unitários para o método `isValidIsbn()` (`services/isbn/tools.js`) utilizando a cobertura de decisões/condições modificada (MD/DC).

## Casos de Teste (CTs)
- CT1 — Tamanho inválido (11 dígitos)
- CT2 — ISBN-10 válido (prefixo 85)
- CT3 — ISBN-13 válido (978-85)
- CT4 — Fora do padrão (regex rejeita)