### PR TITLE
Adiciona o campo "Capital" ao retornar dados sobre UFs

### DIFF
--- a/services/ibge/gov.js
+++ b/services/ibge/gov.js
@@ -2,8 +2,52 @@ import axios from 'axios';
 
 const URL_UF = 'https://servicodados.ibge.gov.br/api/v1/localidades/estados';
 
-export const getUfs = () => axios.get(URL_UF);
-export const getUfByCode = (code) => axios.get(`${URL_UF}/${code}`);
+const UF_CAPITAIS = {
+  AC: 'Rio Branco',
+  AL: 'Maceió',
+  AP: 'Macapá',
+  AM: 'Manaus',
+  BA: 'Salvador',
+  CE: 'Fortaleza',
+  DF: 'Brasília',
+  ES: 'Vitória',
+  GO: 'Goiânia',
+  MA: 'São Luís',
+  MT: 'Cuiabá',
+  MS: 'Campo Grande',
+  MG: 'Belo Horizonte',
+  PA: 'Belém',
+  PB: 'João Pessoa',
+  PR: 'Curitiba',
+  PE: 'Recife',
+  PI: 'Teresina',
+  RJ: 'Rio de Janeiro',
+  RN: 'Natal',
+  RS: 'Porto Alegre',
+  RO: 'Porto Velho',
+  RR: 'Boa Vista',
+  SC: 'Florianópolis',
+  SP: 'São Paulo',
+  SE: 'Aracaju',
+  TO: 'Palmas',
+};
+
+const addCapital = (uf) => ({
+  ...uf,
+  capital: UF_CAPITAIS[uf.sigla] ?? null,
+});
+
+export const getUfs = () =>
+  axios.get(URL_UF).then((response) => {
+    response.data = response.data.map(addCapital);
+    return response;
+  });
+
+export const getUfByCode = (code) =>
+  axios.get(`${URL_UF}/${code}`).then((response) => {
+    response.data = addCapital(response.data);
+    return response;
+  });
 
 export const getContiesByUf = async (uf) => {
   const { data } = await axios.get(`${URL_UF}/${uf}/municipios`);

--- a/tests/ibge-uf-v1.test.js
+++ b/tests/ibge-uf-v1.test.js
@@ -4,7 +4,7 @@ import { describe, test, expect, beforeAll } from 'vitest';
 import { testCorsForRoute } from './helpers/cors';
 
 // Smart service availability check - skip only when DNS/network issues are detected
-let shouldSkipTests = true; // Default to skip for safety
+let shouldSkipTests = false; // Default to skip for safety
 
 beforeAll(async () => {
   try {
@@ -45,6 +45,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         sigla: expect.any(String),
         nome: expect.any(String),
       }),
+      capital: expect.any(String),
     });
   });
 
@@ -75,6 +76,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
             sigla: expect.any(String),
             nome: expect.any(String),
           }),
+          capital: expect.any(String),
         }),
       ])
     );
@@ -94,7 +96,9 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         sigla: expect.any(String),
         nome: expect.any(String),
       }),
+      capital: expect.any(String),
     });
+    expect(response.data.capital).toBe('Florianópolis');
   });
 
   test('Utilizando uma Sigla válida: PI', async () => {
@@ -111,7 +115,9 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         sigla: expect.any(String),
         nome: expect.any(String),
       }),
+      capital: expect.any(String),
     });
+    expect(response.data.capital).toBe('Teresina');
   });
 
   test('Utilizando um sigla inexistente ou inválida: SJ', async () => {


### PR DESCRIPTION
# Resumo

Adiciona o campo "Capital" ao retornar dados sobre UFs para o endpoint ```https://brasilapi.com.br/api/ibge/uf/v1```.

Adiciona uma tabela estática de capitais no arquivo ```services/ibge/gov.js```, parecido com a tabela que mapeia as siglas dos estados para seus nomes completos no arquivo ```services/ibge/wikipedia.js```.

Em seguida adiciona esse valor no campo "capital" ao final dos dados retornados.

Também foram atualizados os testes para esse endpoint, cobrindo o novo campo e checando seu valor.

Funcionalidade executada:

<img width="1481" height="681" alt="Print da funcionalidade sendo executada localmente" src="https://github.com/user-attachments/assets/7bbc648c-54a0-4c93-926d-3773e485a68a" />


Closes #744 