### PR TITLE
feat(cptec): add regiao to city search response

### DIFF
--- a/pages/docs/doc/cptec.json
+++ b/pages/docs/doc/cptec.json
@@ -372,7 +372,7 @@
             "City": {
                 "title": "Cidade CPTEC",
                 "description": "Informações de uma cidade disponível nos serviços do CPTEC",
-                "required": ["nome", "estado", "id"],
+                "required": ["nome", "estado", "id", "regiao"],
                 "type": "object",
                 "properties": {
                     "nome": {
@@ -383,6 +383,10 @@
                         "type": "string",
                         "description": "Sigla do estado (UF)"
                     },
+                    "regiao": {
+                        "type": "string",
+                        "description": "Região geográfica do estado (Norte, Nordeste, Centro-Oeste, Sudeste ou Sul)"
+                    },
                     "id": {
                         "type": "integer",
                         "description": "Código único da cidade no sistema CPTEC"
@@ -391,6 +395,7 @@
                 "example": {
                     "nome": "São Benedito",
                     "estado": "CE",
+                    "regiao": "Nordeste",
                     "id": 4750
                 }
             },

--- a/services/cptec/cities.js
+++ b/services/cptec/cities.js
@@ -1,15 +1,19 @@
 import axios from 'axios';
 import { XMLParser } from 'fast-xml-parser';
-import { CPTEC_URL } from './constants';
+import { CPTEC_URL, STATE_REGION_MAP } from './constants';
 
 const parser = new XMLParser();
 
 const formatCity = (city) => {
-  const newCity = city;
-  newCity.estado = city.uf;
-  delete newCity.uf;
+  const estado = city.uf;
+  const regiao = STATE_REGION_MAP[estado] ?? null;
+  const { uf, ...rest } = city;
 
-  return newCity;
+  return {
+    ...rest,
+    estado,
+    regiao,
+  };
 };
 
 /**

--- a/services/cptec/constants.js
+++ b/services/cptec/constants.js
@@ -7,6 +7,36 @@ export const MIN_DAYS = 1;
 export const MAX_SWELL_DAYS = 6;
 export const MAX_WEATHER_DAYS = 6;
 
+export const STATE_REGION_MAP = {
+  AC: 'Norte',
+  AL: 'Nordeste',
+  AM: 'Norte',
+  AP: 'Norte',
+  BA: 'Nordeste',
+  CE: 'Nordeste',
+  DF: 'Centro-Oeste',
+  ES: 'Sudeste',
+  GO: 'Centro-Oeste',
+  MA: 'Nordeste',
+  MT: 'Centro-Oeste',
+  MS: 'Centro-Oeste',
+  MG: 'Sudeste',
+  PA: 'Norte',
+  PB: 'Nordeste',
+  PR: 'Sul',
+  PE: 'Nordeste',
+  PI: 'Nordeste',
+  RJ: 'Sudeste',
+  RN: 'Nordeste',
+  RS: 'Sul',
+  RO: 'Norte',
+  RR: 'Norte',
+  SC: 'Sul',
+  SP: 'Sudeste',
+  SE: 'Nordeste',
+  TO: 'Norte',
+};
+
 /**
  * Descriptions extracted from CPTEC docs:
  * http://servicos.cptec.inpe.br/XML/#condicoes-tempo

--- a/tests/cpetc/cidade-v1.test.js
+++ b/tests/cpetc/cidade-v1.test.js
@@ -40,6 +40,7 @@ describeIf(shouldSkipTests)('cities v1 (E2E)', () => {
         id: 5051,
         nome: 'São Sebastião',
         estado: 'SP',
+        regiao: 'Sudeste',
       });
     });
 
@@ -53,6 +54,7 @@ describeIf(shouldSkipTests)('cities v1 (E2E)', () => {
         id: 222,
         nome: 'Belo Horizonte',
         estado: 'MG',
+        regiao: 'Sudeste',
       });
     });
 


### PR DESCRIPTION
## O que muda
- adiciona o campo `regiao` (ex.: Norte, Nordeste, Sudeste...) no retorno de `/api/cptec/v1/cidade/:name` e `/api/cptec/v1/cidade`
- mapeia UFs → regiões no serviço do CPTEC
- documenta o novo atributo no schema CPTEC

## Por quê
- permite identificar a região da localidade sem consulta extra

## Testes
- npm run test -- tests/cpetc/cidade-v1.test.js

## Exemplo
GET /api/cptec/v1/cidade/Itapevi
[
  { "id": 2583, "nome": "Itapevi", "estado": "SP", "regiao": "Sudeste" }
]

Closes #745

