### PR TITLE
docs: evolução da documentação para contribuidores e triagem de PRs

### DIFF
--- a/.github/CODE_REVIEW_GUIDELINES.md
+++ b/.github/CODE_REVIEW_GUIDELINES.md
@@ -124,6 +124,8 @@ git diff main
 
 ### ✅ 5. Performance e Custos
 
+> ⚠️ O BrasilAPI é open-source e **sem financiamento**. Qualquer mudança que introduza custos de infraestrutura deve ser **rejeitada imediatamente**, independente da qualidade técnica. Não há orçamento para banco de dados, storage ou serviços pagos. Serviços que exigem chave de API ou cadastro prévio devem ser discutidos em issue antes de implementar.
+
 **Verificações Obrigatórias:**
 
 - [ ] Não há loops desnecessários ou processamento pesado
@@ -191,6 +193,9 @@ tree pages/api/[novo-endpoint]
 tree services/
 ```
 
+**Referência:**
+Consulte o [Guia de Criação de Endpoints](../docs/ENDPOINT_GUIDE.md) para os padrões esperados de handler, service, teste e documentação.
+
 **Perguntas a Fazer:**
 - Código segue os padrões existentes no projeto?
 - Há reuso de componentes e serviços?
@@ -222,7 +227,12 @@ As seguintes situações devem resultar em **rejeição imediata** do PR:
    - Processamento pesado sem justificativa
    - Dependências grandes desnecessárias
 
-6. **Código não segue padrões**
+6. **Dependência de infraestrutura paga ou privada**
+   - Banco de dados próprio (qualquer engine)
+   - Storage (S3, GCS, etc.)
+   - Qualquer serviço com custo recorrente ou que exige chave de API privada
+
+7. **Código não segue padrões**
    - ESLint falhando
    - Estrutura diferente do projeto
 

--- a/.github/CODE_REVIEW_GUIDELINES.md
+++ b/.github/CODE_REVIEW_GUIDELINES.md
@@ -194,7 +194,7 @@ tree services/
 ```
 
 **Referência:**
-Consulte o [Guia de Criação de Endpoints](../docs/ENDPOINT_GUIDE.md) para os padrões esperados de handler, service, teste e documentação.
+- [Guia de Criação de Endpoints](../docs/ENDPOINT_GUIDE.md) — padrões esperados de handler, service, teste e documentação.
 
 **Perguntas a Fazer:**
 - Código segue os padrões existentes no projeto?
@@ -224,8 +224,8 @@ As seguintes situações devem resultar em **rejeição imediata** do PR:
    - SQL injection, XSS
 
 5. **Aumento significativo de custos**
-   - Processamento pesado sem justificativa
-   - Dependências grandes desnecessárias
+   - Processamento pesado sem justificativa (loops aninhados, recursão sem limite, etc.)
+   - Dependências novas grandes ou sem justificativa clara
 
 6. **Dependência de infraestrutura paga ou privada**
    - Banco de dados próprio (qualquer engine)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# BrasilAPI — CLAUDE.md
+
+Projeto open-source de API pública para dados brasileiros. Usado por milhares de desenvolvedores e empresas em produção.
+
+## Stack
+
+- **Framework:** Next.js 12, API routes em `pages/api/`
+- **Testes:** Vitest 3 (E2E, faz chamadas HTTP reais ao servidor local)
+- **Lint:** ESLint (Airbnb) + Prettier
+- **Commits:** Conventional Commits via `npm run commit`
+- **Node:** >=20 <22 | **npm:** >=10
+
+## Comandos
+
+```bash
+npm run dev        # servidor Next.js local
+npm test           # inicia Next.js + Vitest concorrentemente
+npm run fix        # ESLint autofix
+npm run commit     # commit interativo (conventional commits)
+```
+
+## Arquitetura
+
+### Estrutura de diretórios
+
+```
+pages/api/{domínio}/v{n}/[param].js   # handlers (roteamento + resposta)
+services/{domínio}/                    # lógica de negócio e chamadas externas
+tests/{domínio}-v{n}.test.js           # testes E2E
+pages/docs/doc/{domínio}.json          # documentação OpenAPI 3.0
+errors/                                # BadRequestError, NotFoundError, etc.
+middlewares/                           # cors, cache, logger, errorHandler, firewall
+util/                                  # funções utilitárias pequenas
+lib/                                   # helpers de suporte
+```
+
+Para criar um novo endpoint do zero, use o [Guia de Criação de Endpoints](docs/ENDPOINT_GUIDE.md) — inclui templates prontos para handler, service, teste e OpenAPI.
+
+### Padrão de handler
+
+```js
+import app from '@/app';
+import ServiceError from '@/errors/BadRequestError';
+import { myServiceFunction } from '@/services/domain';
+
+async function handler(request, response) {
+  const { param } = request.query;
+  const data = await myServiceFunction(param);
+  return response.status(200).json(data);
+}
+
+export default app().get(handler);
+```
+
+- `app()` é um wrapper `next-connect` com middlewares já aplicados (cors, cache, logger, firewall, errorHandler)
+- Erros devem ser lançados como instâncias das classes em `errors/` — o `errorHandler` formata a resposta
+- Não use try/catch genérico no handler; deixe o middleware tratar erros inesperados
+
+### Classes de erro
+
+| Classe | Status |
+|---|---|
+| `BadRequestError` | 400 |
+| `UnauthorizedError` | 401 |
+| `NotFoundError` | 404 |
+| `InternalError` | 500 |
+
+### Padrão de teste
+
+```js
+import { describe, test, expect, beforeAll } from 'vitest';
+import axios from 'axios';
+import { testCorsForRoute } from '../helpers';
+
+describe('domain v1', () => {
+  beforeAll(async () => { /* aguarda servidor */ });
+
+  test('GET /api/domain/v1/[param] com parâmetro válido', async () => {
+    const { status, data } = await axios.get(`${global.SERVER_URL}/api/domain/v1/param`);
+    expect(status).toBe(200);
+    expect(data).toHaveProperty('field');
+  });
+
+  test('GET /api/domain/v1/[param] com parâmetro inválido', async () => {
+    await expect(axios.get(`${global.SERVER_URL}/api/domain/v1/invalid`))
+      .rejects.toMatchObject({ response: { status: 400 } });
+  });
+
+  testCorsForRoute('/api/domain/v1/param');
+});
+```
+
+- Testes fazem chamadas HTTP reais — o servidor precisa estar rodando
+- `fileParallelism: false` — testes rodam sequencialmente
+- Cobrir: sucesso, erros (400, 404, 500), CORS
+
+## Princípios inegociáveis
+
+### 1. Compatibilidade retroativa é NON-NEGOTIABLE
+
+A BrasilAPI é usada em produção. Nunca:
+- Remover ou renomear campos de resposta existentes
+- Mudar tipos de dados de campos existentes
+- Alterar URLs ou status HTTP de endpoints existentes
+
+Se uma mudança quebra compatibilidade → criar nova versão (`v2`, `v3`).
+
+### 2. Zero custos de infraestrutura
+
+O projeto é open-source e sem financiamento. Isso é uma restrição arquitetural, não apenas de performance:
+- Nenhum endpoint pode depender de banco de dados próprio, storage ou serviço pago
+- Todos os dados devem vir de fontes públicas e gratuitas
+- Dependências novas devem ser justificadas e leves
+- Cache deve ser usado quando possível (middleware `cache` já está disponível via `app()`)
+
+### 3. Documentação obrigatória
+
+Todo endpoint novo ou modificado precisa de documentação OpenAPI em `pages/docs/doc/`. Use o schema `ErrorMessage` para respostas de erro.
+
+## Revisão de PRs
+
+Para triagem e revisão de PRs, consulte:
+- `.github/CODE_REVIEW_GUIDELINES.md` — critérios detalhados de revisão
+- `.github/PULL_REQUEST_TEMPLATE.md` — checklist do autor
+
+### Bloqueiam o merge (não aprovar sem correção)
+
+- Quebra de compatibilidade retroativa sem nova versão
+- Endpoint sem documentação OpenAPI
+- Testes ausentes ou falhando (`npm test`)
+- Secrets, credenciais ou tokens no código
+- Dependência de banco de dados, storage ou serviço pago
+- ESLint falhando (`npm run fix` com erros não corrigidos)
+- Commit sem seguir Conventional Commits
+
+### Sugestões (não bloqueiam, mas vale apontar)
+
+- Performance subótima (ex: chamada externa que poderia ser cacheada)
+- Nomes de variáveis/funções pouco descritivos
+- Tratamento de edge cases ausente mas não crítico
+- Código que poderia ser simplificado
+
+## Path alias
+
+`@` aponta para a raiz do projeto (configurado em `jsconfig.json` / `next.config.js`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Para criar um novo endpoint do zero, use o [Guia de Criação de Endpoints](docs
 
 ```js
 import app from '@/app';
-import ServiceError from '@/errors/BadRequestError';
+import BadRequestError from '@/errors/BadRequestError';
 import { myServiceFunction } from '@/services/domain';
 
 async function handler(request, response) {
@@ -110,6 +110,7 @@ Se uma mudança quebra compatibilidade → criar nova versão (`v2`, `v3`).
 O projeto é open-source e sem financiamento. Isso é uma restrição arquitetural, não apenas de performance:
 - Nenhum endpoint pode depender de banco de dados próprio, storage ou serviço pago
 - Todos os dados devem vir de fontes públicas e gratuitas
+- Serviços que exigem chave de API ou cadastro prévio devem ser discutidos em issue antes de implementar
 - Dependências novas devem ser justificadas e leves
 - Cache deve ser usado quando possível (middleware `cache` já está disponível via `app()`)
 
@@ -127,11 +128,11 @@ Para triagem e revisão de PRs, consulte:
 
 - Quebra de compatibilidade retroativa sem nova versão
 - Endpoint sem documentação OpenAPI
-- Testes ausentes ou falhando (`npm test`)
+- Testes ausentes para novos endpoints ou mudanças de comportamento, ou testes falhando (`npm test`)
 - Secrets, credenciais ou tokens no código
-- Dependência de banco de dados, storage ou serviço pago
-- ESLint falhando (`npm run fix` com erros não corrigidos)
-- Commit sem seguir Conventional Commits
+- Dependência de banco de dados próprio, storage, ou serviço pago/que exige chave de API privada
+- ESLint com erros (`npm run fix` deve passar sem erros restantes)
+- Commit sem seguir Conventional Commits (`feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`)
 
 ### Sugestões (não bloqueiam, mas vale apontar)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 # :link: Como contribuir
 
+## Princípios do projeto
+
+- **Open-source e sem financiamento:** O BrasilAPI não tem custos de infraestrutura e deve permanecer assim. Nenhum endpoint pode depender de banco de dados próprio, storage ou qualquer serviço pago. Todos os dados devem vir de fontes públicas e gratuitas.
+- **API pública em produção:** O projeto é usado por milhares de desenvolvedores e empresas. Mudanças devem ser feitas com cuidado para não quebrar integrações existentes.
+- **Comunidade:** Qualquer contribuição que agregue valor é bem-vinda, desde que siga estes princípios.
+
 Qualquer ajuda que agregue valor ao projeto, seja na edição do código-fonte ou nas documentações, e consequentemente a vida das pessoas é muito bem-vindo, por isso decidimos torna-lo opensource.
 
 ## Iniciando
@@ -11,6 +17,8 @@ Certifique-se de estar na pasta raiz do projeto para executar:
 ```npm run dev``` - nextjs local
 
 ```npm run fix``` - ESLint
+
+Para criar um novo endpoint do zero, siga o [Guia de Criação de Endpoints](docs/ENDPOINT_GUIDE.md).
 
 ## Mensagens de commit
 
@@ -50,6 +58,21 @@ Para mensagens de erro utilize o schema pré-existente `ErrorMessage`
              }
          }
      }
+
+## Compatibilidade de API
+
+A BrasilAPI é usada em produção por milhares de aplicações. **Nunca** faça as seguintes mudanças em endpoints existentes:
+
+- Remover ou renomear campos da resposta
+- Mudar o tipo de um campo (`string` → `number`, etc.)
+- Alterar a URL de um endpoint existente
+- Mudar códigos de status HTTP de respostas de sucesso
+
+Se sua mudança exige qualquer um desses itens → crie uma nova versão do endpoint (`/v2`, `/v3`), mantendo a versão anterior funcionando.
+
+Adicionar novos campos opcionais ou criar novos endpoints é sempre compatível e não requer nova versão.
+
+Para um guia completo com exemplos, consulte [docs/ENDPOINT_GUIDE.md](docs/ENDPOINT_GUIDE.md).
 
 ## Pull requests (PRs)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,6 @@
 - **API pública em produção:** O projeto é usado por milhares de desenvolvedores e empresas. Mudanças devem ser feitas com cuidado para não quebrar integrações existentes.
 - **Comunidade:** Qualquer contribuição que agregue valor é bem-vinda, desde que siga estes princípios.
 
-Qualquer ajuda que agregue valor ao projeto, seja na edição do código-fonte ou nas documentações, e consequentemente a vida das pessoas é muito bem-vindo, por isso decidimos torna-lo opensource.
-
 ## Iniciando
 
 Certifique-se de estar na pasta raiz do projeto para executar:

--- a/docs/ENDPOINT_GUIDE.md
+++ b/docs/ENDPOINT_GUIDE.md
@@ -48,11 +48,41 @@ async function getDominioById(request, response) {
 export default app().get(getDominioById);
 ```
 
+#### Exemplo com tratamento de erros de biblioteca externa
+
+```js
+import app from '@/app';
+import BaseError from '@/errors/BaseError';
+import InternalError from '@/errors/InternalError';
+import { getDominioData } from '@/services/dominio';
+
+// Quando o service usa uma biblioteca que lança erros não tipados:
+async function getDominioById(request, response) {
+  const { param } = request.query;
+
+  try {
+    const data = await getDominioData(param);
+    return response.status(200).json(data);
+  } catch (error) {
+    if (error instanceof BaseError) throw error; // já tipado, propaga
+
+    // Converte erro da biblioteca externa em erro tipado
+    throw new InternalError({
+      message: 'Erro ao consultar dados.',
+      type: 'DOMINIO_ERROR',
+    });
+  }
+}
+
+export default app().get(getDominioById);
+```
+
 **Regras do handler:**
 - Use `app()` sempre — ele já inclui cors, cache, logger, firewall e errorHandler
 - Lance erros usando as classes de `@/errors/` — o `errorHandler` formata a resposta automaticamente
-- Não use `try/catch` genérico — deixe erros inesperados propagarem para o middleware
-- Para cache customizado: `app({ cache: 86400 }).get(handler)` (segundos; padrão é 86400)
+- Não use `try/catch` genérico para silenciar erros. Use try/catch quando precisar converter erros de bibliotecas externas em erros tipados antes de relançar (ex: converter um erro da biblioteca cep-promise em `BadRequestError`). Erros inesperados devem propagar normalmente para o `errorHandler`.
+- Handlers antigos no projeto podem não seguir estes padrões (ex: retornar JSON diretamente com `response.json()` sem usar as classes de erro). Para **novos** endpoints, sempre use as classes de `@/errors/`.
+- Para cache customizado: `app({ cache: 3600 }).get(handler)` (valor em segundos). O padrão já é 86400s (24h) — só passe `cache:` quando quiser um valor diferente.
 
 ### Service — `services/{dominio}.js`
 
@@ -86,6 +116,7 @@ export async function getDominioData(param) {
 - Lance erros tipados (`NotFoundError`, `BadRequestError`, `InternalError`) — nunca objetos literais
 - Faça transformação/normalização dos dados aqui, não no handler
 - Valide o input antes de chamar a API externa
+- A validação de input pode ficar no handler ou no service — siga o padrão do domínio mais próximo ao que você está criando. Se a validação é simples e específica do HTTP (ex: verificar formato do parâmetro de URL), pode ficar no handler. Se envolve regras de negócio, coloque no service.
 
 ### Teste — `tests/{dominio}-v1.test.js`
 
@@ -143,6 +174,13 @@ describe('dominio v1 (E2E)', () => {
 - `npm test` inicia o servidor e o Vitest automaticamente (via `concurrently`)
 - Sempre cubra: CORS, sucesso (200), não encontrado (404), parâmetro inválido (400 — se aplicável)
 - Use `expect.assertions(N)` em blocos `try/catch` para garantir que o erro foi lançado
+- Antes de testar, verifique se `global.SERVER_URL` está configurado — ele é definido automaticamente em `tests/helpers/server/setup.js` e aponta para o servidor local iniciado pelo `npm test`.
+- O projeto tem um helper `testCorsForRoute` em `tests/helpers/cors.js` que faz verificações de CORS mais completas (preflight, métodos permitidos, headers). Prefira usá-lo quando disponível:
+  ```js
+  import { testCorsForRoute } from '../helpers/cors';
+  testCorsForRoute('/api/dominio/v1/param-valido');
+  ```
+- ⚠️ `npm test` executa `kill-port 3000` antes de iniciar — qualquer processo rodando na porta 3000 será encerrado automaticamente.
 
 ### Documentação OpenAPI — `pages/docs/doc/{dominio}.json`
 
@@ -159,7 +197,6 @@ describe('dominio v1 (E2E)', () => {
       "get": {
         "tags": ["DOMINIO"],
         "summary": "Descrição curta do que este endpoint retorna",
-        "description": "",
         "parameters": [
           {
             "name": "param",
@@ -230,6 +267,7 @@ describe('dominio v1 (E2E)', () => {
 - Use sempre `"$ref": "#/components/schemas/ErrorMessage"` para respostas de erro — este schema já existe globalmente
 - Adicione exemplos realistas no campo `"example"`
 - Documentação em português
+- O schema `ErrorMessage` é global — não declare-o em `components.schemas` do seu arquivo. Use apenas `$ref: "#/components/schemas/ErrorMessage"`. O schema do seu endpoint de sucesso (ex: `Dominio`) deve ser declarado localmente em `components.schemas`.
 
 ---
 

--- a/docs/ENDPOINT_GUIDE.md
+++ b/docs/ENDPOINT_GUIDE.md
@@ -1,0 +1,279 @@
+# Guia de Criação de Endpoints
+
+## Antes de Começar
+
+Antes de escrever uma linha de código, confirme todos os itens:
+
+- [ ] A fonte de dados é **pública e gratuita**?
+- [ ] A API/fonte externa é estável e mantida?
+- [ ] Não há necessidade de banco de dados ou storage próprio?
+- [ ] Existe documentação pública da fonte de dados?
+
+> ⚠️ **O BrasilAPI é open-source e sem financiamento.** Não temos como arcar com custos de infraestrutura. Nenhum endpoint pode depender de banco de dados próprio, storage ou qualquer serviço pago. Todos os dados devem vir de fontes públicas e gratuitas.
+
+Se algum item acima não puder ser confirmado, abra uma issue antes de implementar para discutir a viabilidade.
+
+---
+
+## Estrutura de Arquivos
+
+Para um endpoint `GET /api/{dominio}/v1/[param]`, crie os seguintes arquivos:
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `pages/api/{dominio}/v1/[param].js` | Handler: roteamento e resposta HTTP |
+| `services/{dominio}.js` | Lógica de negócio e chamadas a APIs externas |
+| `tests/{dominio}-v1.test.js` | Testes E2E |
+| `pages/docs/doc/{dominio}.json` | Documentação OpenAPI 3.0 |
+
+Para múltiplos sub-serviços, use um diretório: `services/{dominio}/index.js`.
+
+---
+
+## Templates
+
+### Handler — `pages/api/{dominio}/v1/[param].js`
+
+```js
+import app from '@/app';
+import NotFoundError from '@/errors/NotFoundError';
+import { getDominioData } from '@/services/dominio';
+
+async function getDominioById(request, response) {
+  const { param } = request.query;
+  const data = await getDominioData(param);
+  return response.status(200).json(data);
+}
+
+export default app().get(getDominioById);
+```
+
+**Regras do handler:**
+- Use `app()` sempre — ele já inclui cors, cache, logger, firewall e errorHandler
+- Lance erros usando as classes de `@/errors/` — o `errorHandler` formata a resposta automaticamente
+- Não use `try/catch` genérico — deixe erros inesperados propagarem para o middleware
+- Para cache customizado: `app({ cache: 86400 }).get(handler)` (segundos; padrão é 86400)
+
+### Service — `services/{dominio}.js`
+
+```js
+import axios from 'axios';
+import NotFoundError from '@/errors/NotFoundError';
+import BadRequestError from '@/errors/BadRequestError';
+
+export async function getDominioData(param) {
+  if (!param || !/^[a-z0-9]+$/i.test(param)) {
+    throw new BadRequestError({
+      message: 'Parâmetro inválido.',
+      type: 'DOMINIO_INVALID_PARAM',
+    });
+  }
+
+  const { data } = await axios.get(`https://fonte-publica.gov.br/api/${param}`);
+
+  if (!data) {
+    throw new NotFoundError({
+      message: 'Recurso não encontrado.',
+      type: 'DOMINIO_NOT_FOUND',
+    });
+  }
+
+  return data;
+}
+```
+
+**Regras do service:**
+- Lance erros tipados (`NotFoundError`, `BadRequestError`, `InternalError`) — nunca objetos literais
+- Faça transformação/normalização dos dados aqui, não no handler
+- Valide o input antes de chamar a API externa
+
+### Teste — `tests/{dominio}-v1.test.js`
+
+```js
+import axios from 'axios';
+import { describe, expect, test } from 'vitest';
+
+describe('dominio v1 (E2E)', () => {
+  describe('GET /api/dominio/v1/:param', () => {
+    test('Verifica CORS', async () => {
+      const response = await axios.get(
+        `${global.SERVER_URL}/api/dominio/v1/param-valido`
+      );
+      expect(response.headers['access-control-allow-origin']).toBe('*');
+    });
+
+    test('Retorna dados para parâmetro válido', async () => {
+      const response = await axios.get(
+        `${global.SERVER_URL}/api/dominio/v1/param-valido`
+      );
+      expect(response.status).toBe(200);
+      expect(response.data).toMatchObject({
+        campo1: expect.any(String),
+        campo2: expect.any(Number),
+      });
+    });
+
+    test('Retorna 404 para parâmetro inexistente', async () => {
+      expect.assertions(2);
+      try {
+        await axios.get(`${global.SERVER_URL}/api/dominio/v1/param-inexistente-xyz`);
+      } catch (error) {
+        expect(error.response.status).toBe(404);
+        expect(error.response.data).toMatchObject({
+          message: expect.any(String),
+          type: expect.any(String),
+        });
+      }
+    });
+
+    test('Retorna 400 para parâmetro inválido', async () => {
+      expect.assertions(1);
+      try {
+        await axios.get(`${global.SERVER_URL}/api/dominio/v1/????`);
+      } catch (error) {
+        expect(error.response.status).toBe(400);
+      }
+    });
+  });
+});
+```
+
+**Regras dos testes:**
+- Testes são E2E — fazem chamadas HTTP reais contra o servidor local em `global.SERVER_URL`
+- `npm test` inicia o servidor e o Vitest automaticamente (via `concurrently`)
+- Sempre cubra: CORS, sucesso (200), não encontrado (404), parâmetro inválido (400 — se aplicável)
+- Use `expect.assertions(N)` em blocos `try/catch` para garantir que o erro foi lançado
+
+### Documentação OpenAPI — `pages/docs/doc/{dominio}.json`
+
+```json
+{
+  "tags": [
+    {
+      "name": "DOMINIO",
+      "description": "Descrição do domínio"
+    }
+  ],
+  "paths": {
+    "/dominio/v1/{param}": {
+      "get": {
+        "tags": ["DOMINIO"],
+        "summary": "Descrição curta do que este endpoint retorna",
+        "description": "",
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "description": "Descrição do parâmetro",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dominio"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recurso não encontrado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "message": "Recurso não encontrado",
+                  "type": "DOMINIO_NOT_FOUND"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Dominio": {
+        "title": "Dominio",
+        "required": ["campo1", "campo2"],
+        "type": "object",
+        "properties": {
+          "campo1": {
+            "type": "string",
+            "description": "Descrição do campo"
+          },
+          "campo2": {
+            "type": "integer",
+            "description": "Descrição do campo"
+          }
+        },
+        "example": {
+          "campo1": "valor-exemplo",
+          "campo2": 123
+        }
+      }
+    }
+  }
+}
+```
+
+**Notas:**
+- Use sempre `"$ref": "#/components/schemas/ErrorMessage"` para respostas de erro — este schema já existe globalmente
+- Adicione exemplos realistas no campo `"example"`
+- Documentação em português
+
+---
+
+## Compatibilidade de API
+
+> ⚠️ **CRÍTICO:** A BrasilAPI é usada por milhares de aplicações em produção. Uma mudança incompatível pode derrubar apps reais de forma silenciosa.
+
+### O que **nunca** pode mudar em endpoints existentes
+
+| Proibido | Como resolver sem quebrar |
+|---|---|
+| Remover um campo da resposta | Manter o campo (mesmo que `null`) |
+| Renomear um campo | Adicionar campo novo com o nome correto, manter o antigo |
+| Mudar tipo de um campo (`string` → `number`) | Adicionar campo novo com tipo correto, manter o antigo |
+| Alterar a URL do endpoint | Criar nova versão (`/v2/`) |
+| Mudar código de status HTTP de respostas de sucesso | Criar nova versão |
+
+### Quando criar uma nova versão (`v2`)
+
+Se a sua mudança se enquadra em qualquer item da tabela acima → crie `/v2`:
+
+1. Novo handler: `pages/api/{dominio}/v2/[param].js`
+2. Novos testes: `tests/{dominio}-v2.test.js`
+3. Adicionar paths `/dominio/v2/...` na documentação existente (`pages/docs/doc/{dominio}.json`)
+4. Manter a v1 funcionando normalmente (não apague, não modifique)
+
+### Mudanças sempre compatíveis ✅
+
+- Adicionar **novos campos** à resposta (clientes que não conhecem o campo simplesmente ignoram)
+- Criar novos endpoints
+- Adicionar novos parâmetros **opcionais** a endpoints existentes
+- Corrigir valores incorretos de campos existentes (desde que o tipo e nome não mudem)
+
+---
+
+## Checklist Final
+
+Antes de abrir o PR, confirme:
+
+- [ ] `npm test` passa sem erros
+- [ ] `npm run fix` executado sem erros de lint
+- [ ] Handler usa `app()` e lança erros com as classes de `@/errors/`
+- [ ] Service não depende de banco de dados, storage ou serviço pago
+- [ ] Documentação OpenAPI criada/atualizada em `pages/docs/doc/`
+- [ ] Testes cobrem: CORS, sucesso (200), não encontrado (404), parâmetro inválido (400)
+- [ ] Endpoints e campos existentes não foram modificados de forma incompatível
+- [ ] Commit segue Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)


### PR DESCRIPTION
## Summary

- Cria `docs/ENDPOINT_GUIDE.md` com guia passo a passo e templates prontos para handler, service, teste E2E e documentação OpenAPI — reduz erros de padrão em novos PRs
- Atualiza `CONTRIBUTING.md` com princípios do projeto (sem custos de infra, fontes públicas gratuitas) e seção de compatibilidade de API com regras de versionamento
- Atualiza `CLAUDE.md` com restrição de infra como restrição arquitetural explícita e critérios claros de bloqueio vs. sugestão para triagem de PRs
- Atualiza `.github/CODE_REVIEW_GUIDELINES.md` reforçando a restrição de infra e referenciando o novo guia de endpoints

## Motivação

Os erros mais frequentes em PRs da comunidade são quebra de compatibilidade retroativa e código fora dos padrões do projeto. Esta evolução da documentação ataca os dois problemas com uma fonte única de verdade (`ENDPOINT_GUIDE.md`) e linguagem mais direta nos docs existentes.

## Test Plan

- [ ] Ler `docs/ENDPOINT_GUIDE.md` e verificar se os templates compilam corretamente
- [ ] Verificar que os links para `docs/ENDPOINT_GUIDE.md` em `CONTRIBUTING.md`, `CLAUDE.md` e `CODE_REVIEW_GUIDELINES.md` resolvem corretamente
- [ ] Confirmar que nenhum arquivo de código foi modificado (`git diff main --name-only` deve mostrar apenas `.md` e `.json` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)