### PR TITLE
fix(ncm): corrige campos tipo_ato, numero_ato e ano_ato ausentes no fallback

### DIFF
--- a/services/sefaz/index.js
+++ b/services/sefaz/index.js
@@ -12,9 +12,12 @@ function parseObject(obj) {
   );
 
   const {
-    tipo_ato_ini: tipoAtoIni,
-    numero_ato_ini: numeroAtoIni,
-    ano_ato_ini: anoAtoIni,
+    tipo_ato_ini,
+    numero_ato_ini,
+    ano_ato_ini,
+    tipo_ato,
+    numero_ato,
+    ano_ato,
     data_inicio: dataInicio,
     data_fim: dataFim,
     ...rest
@@ -24,9 +27,9 @@ function parseObject(obj) {
     ...rest,
     data_inicio: formatDate(dataInicio),
     data_fim: formatDate(dataFim),
-    tipo_ato: tipoAtoIni,
-    numero_ato: numeroAtoIni,
-    ano_ato: anoAtoIni,
+    tipo_ato: tipo_ato_ini ?? tipo_ato,
+    numero_ato: numero_ato_ini ?? numero_ato,
+    ano_ato: ano_ato_ini ?? ano_ato,
   };
 
   return newObj;


### PR DESCRIPTION
## 📋 Descrição                                                                           
   
  Corrige a função `parseObject` em `services/sefaz/index.js` que produzia `undefined`      
  para os campos `tipo_ato`, `numero_ato` e `ano_ato` quando o fallback local
  (`ncmList.json`) era usado.                                                               
                                                                                            
  O upstream Siscomex usa chaves com sufixo `_ini` (`Tipo_Ato_Ini`), mas o fallback
  usa sem sufixo (`Tipo_Ato`). Agora ambas as variantes são extraídas e o operador `??`     
  seleciona a disponível.                                                                   
                                                                                            
  Possivelmente uma regressão de #583 (fixado em #585).                                     
                                                                                            
  ## 🎯 Tipo de Mudança                                                                     
                                                                                            
  - [x] 🐛 Correção de bug (mudança que corrige um problema)                                
                                                                                            
  ## ⚠️  Checklist de Compatibilidade (CRÍTICO)              
                                                                                            
  - [x] ✅ Não remove campos de respostas de API existentes 
  - [x] ✅ Não renomeia campos de respostas de API existentes                               
  - [x] ✅ Não muda tipos de dados de campos existentes (string → number, etc.)
  - [x] ✅ Não muda o formato de URLs de endpoints existentes                               
  - [x] ✅ Não muda códigos de status HTTP de endpoints existentes
  - [x] ✅ Se fez mudanças incompatíveis, criei uma nova versão (v2, v3, etc.)
                                                                                            
  ## 📚 Checklist de Documentação         
                                                                                            
  - [x] ✅ N/A - Mudanças não requerem documentação                                         
   
  Os campos já estavam documentados no OpenAPI, apenas não apareciam na resposta.           
                                                            
  ## 🧪 Checklist de Testes
                                                                                            
  - [x] ✅ Todos os testes passam localmente (`npm test`)
  - [x] ✅ Teste de CORS funciona corretamente                                              
  - [x] ✅ Testei casos de erro (404, 400, 500, etc.)       
  - [x] ✅ Testei casos de sucesso        
  - [ ] ✅ N/A - Mudanças não requerem testes
                                                                                            
  Testes existentes em `tests/ncm-v1.test.js` já cobriam esses campos — estavam falhando por
   causa do bug. Agora passam 9/9.                                                          
                                                                                            
  ## 💻 Checklist de Código                                                                 
                                                                                            
  - [x] ✅ Código segue os padrões do projeto (ESLint + Prettier)                           
  - [x] ✅ Não adicionei dependências desnecessárias ou pesadas
  - [x] ✅ Código não expõe credenciais ou informações sensíveis
  - [x] ✅ Tratei erros apropriadamente                                                     
  - [x] ✅ Usei Conventional Commits      
                                                                                            
  ## 🚀 Checklist de Performance e Custos                                                   
   
  - [x] ✅ Não adicionei processamento pesado que aumenta custos                            
  - [x] ✅ Minimizei chamadas a APIs externas               
  - [x] ✅ Considerei impacto em rate limits de APIs externas
                                                                                            
  ## 🔍 Como Testar                       
                                                                                            
  1. `curl https://brasilapi.com.br/api/ncm/v1/33051000` — hoje retorna sem `tipo_ato`,     
  `numero_ato`, `ano_ato`                 
  2. Com o fix: `npm test` — testes do NCM passam 9/9                                       
  3. Verificar que a resposta inclui os 3 campos restaurados                                
                                              
  ## 📎 Issues Relacionadas                                                                 
                                                                                            
  - Closes #796                                                                             
  - Relacionado: #583, #585 