### PR TITLE
fix(ibge): corrigir busca por código numérico e mensagem de erro no endpoint /ibge/uf/v1

### DIFF
--- a/tests/ibge-uf-v1.test.js
+++ b/tests/ibge-uf-v1.test.js
@@ -142,9 +142,9 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
       expect(response.status).toBe(404);
       expect(response.data).toMatchObject({
         name: 'NotFoundError',
-        message: 'UF não encontrada.',
         type: 'not_found',
       });
+      expect(response.data.message).toContain('não encontrada');
     }
   });
 });

--- a/tests/ibge-uf-v1.test.js
+++ b/tests/ibge-uf-v1.test.js
@@ -48,7 +48,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual({
+    expect(response.data).toEqual(expect.objectContaining({
       id: 22,
       sigla: expect.any(String),
       nome: expect.any(String),
@@ -58,7 +58,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         nome: expect.any(String),
       }),
       capital: expect.any(String),
-    });
+    }));
   });
 
   test('Utilizando um Codigo inexistente ou inválido: 99', async () => {
@@ -99,7 +99,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual({
+    expect(response.data).toEqual(expect.objectContaining({
       id: 42,
       sigla: expect.any(String),
       nome: expect.any(String),
@@ -109,7 +109,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         nome: expect.any(String),
       }),
       capital: expect.any(String),
-    });
+    }));
     expect(response.data.capital).toBe('Florianópolis');
   });
 
@@ -118,7 +118,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual({
+    expect(response.data).toEqual(expect.objectContaining({
       id: 22,
       sigla: expect.any(String),
       nome: expect.any(String),
@@ -128,7 +128,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         nome: expect.any(String),
       }),
       capital: expect.any(String),
-    });
+    }));
     expect(response.data.capital).toBe('Teresina');
   });
 

--- a/tests/ibge-uf-v1.test.js
+++ b/tests/ibge-uf-v1.test.js
@@ -3,6 +3,18 @@ import { describe, test, expect, beforeAll } from 'vitest';
 
 import { testCorsForRoute } from './helpers/cors';
 
+const validUfSchema = expect.objectContaining({
+  id: expect.any(Number),
+  sigla: expect.any(String),
+  nome: expect.any(String),
+  regiao: expect.objectContaining({
+    id: expect.any(Number),
+    sigla: expect.any(String),
+    nome: expect.any(String),
+  }),
+  capital: expect.any(String),
+});
+
 // Smart service availability check - skip only when DNS/network issues are detected
 let shouldSkipTests = false; // Default to skip for safety
 
@@ -48,17 +60,8 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual(expect.objectContaining({
-      id: 22,
-      sigla: expect.any(String),
-      nome: expect.any(String),
-      regiao: expect.objectContaining({
-        id: expect.any(Number),
-        sigla: expect.any(String),
-        nome: expect.any(String),
-      }),
-      capital: expect.any(String),
-    }));
+    expect(response.data).toEqual(validUfSchema);
+    expect(response.data.id).toBe(22);
   });
 
   test('Utilizando um Codigo inexistente ou inválido: 99', async () => {
@@ -78,19 +81,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
 
     expect(response.status).toBe(200);
     expect(response.data).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: expect.any(Number),
-          sigla: expect.any(String),
-          nome: expect.any(String),
-          regiao: expect.objectContaining({
-            id: expect.any(Number),
-            sigla: expect.any(String),
-            nome: expect.any(String),
-          }),
-          capital: expect.any(String),
-        }),
-      ])
+      expect.arrayContaining([validUfSchema])
     );
   });
 
@@ -99,17 +90,8 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual(expect.objectContaining({
-      id: 42,
-      sigla: expect.any(String),
-      nome: expect.any(String),
-      regiao: expect.objectContaining({
-        id: expect.any(Number),
-        sigla: expect.any(String),
-        nome: expect.any(String),
-      }),
-      capital: expect.any(String),
-    }));
+    expect(response.data).toEqual(validUfSchema);
+    expect(response.data.id).toBe(42);
     expect(response.data.capital).toBe('Florianópolis');
   });
 
@@ -118,17 +100,8 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual(expect.objectContaining({
-      id: 22,
-      sigla: expect.any(String),
-      nome: expect.any(String),
-      regiao: expect.objectContaining({
-        id: expect.any(Number),
-        sigla: expect.any(String),
-        nome: expect.any(String),
-      }),
-      capital: expect.any(String),
-    }));
+    expect(response.data).toEqual(validUfSchema);
+    expect(response.data.id).toBe(22);
     expect(response.data.capital).toBe('Teresina');
   });
 

--- a/util/mapUfToUfCode.js
+++ b/util/mapUfToUfCode.js
@@ -36,8 +36,13 @@ const UF_CODE_MAPPER = {
  * @returns {number} UF Code
  */
 export default function mapUfToUfCode(uf) {
-    uf = uf.toUpperCase();
-    let ufCode = UF_CODE_MAPPER[uf];
+    const ufCodes = Object.values(UF_CODE_MAPPER);
+    const numericInput = Number(uf);
+    if (Number.isInteger(numericInput) && ufCodes.includes(numericInput)) {
+        return numericInput;
+    }
+
+    const ufCode = UF_CODE_MAPPER[uf.toUpperCase()];
     if(!ufCode){
         throw new NotFoundError(`UF ${uf} não encontrado`);
     }

--- a/util/mapUfToUfCode.js
+++ b/util/mapUfToUfCode.js
@@ -44,7 +44,7 @@ export default function mapUfToUfCode(uf) {
 
     const ufCode = UF_CODE_MAPPER[uf.toUpperCase()];
     if(!ufCode){
-        throw new NotFoundError(`UF ${uf} não encontrado`);
+        throw new NotFoundError({ message: `UF ${uf} não encontrada.` });
     }
 
     return ufCode;


### PR DESCRIPTION
## 📋 Descrição                                                                           
                                                            
  Duas correções no endpoint `/api/ibge/uf/v1/:code`:                                       
   
  1. **Código numérico retornava 404**: A função `mapUfToUfCode` em `util/mapUfToUfCode.js` 
  só aceitava siglas (`PI`, `SC`), rejeitando códigos numéricos (`22`, `42`) com
  `NotFoundError`. Agora reconhece códigos numéricos válidos e os retorna diretamente.      
                                                                                            
  2. **Mensagem de erro vazia para UF inválida**: `mapUfToUfCode` passava string ao         
  construtor de `NotFoundError`, que espera objeto `{ message }`. Isso produzia             
  `message: ""` na resposta. Agora passa o formato correto e mantém o valor dinâmico        
  (ex: `"UF SJ não encontrada."`).                                                          
                                                                                            
  Também atualiza os testes para usar `objectContaining`, acomodando os campos              
  `populacao_estimada` e `periodo` que foram adicionados ao endpoint após a criação
  dos testes.                                                                               
                                                            
  ## 🎯 Tipo de Mudança

  - [x] 🐛 Correção de bug (mudança que corrige um problema)                                
   
  ## ⚠️  Checklist de Compatibilidade (CRÍTICO)                                              
                                                            
  - [x] ✅ Não remove campos de respostas de API existentes                                 
  - [x] ✅ Não renomeia campos de respostas de API existentes
  - [x] ✅ Não muda tipos de dados de campos existentes                                     
  - [x] ✅ Não muda o formato de URLs de endpoints existentes
  - [x] ✅ Não muda códigos de status HTTP de endpoints existentes                          
  - [x] ✅ Se fez mudanças incompatíveis, criei uma nova versão
                                                                                            
  ## 📚 Checklist de Documentação                                                           
   
  - [x] ✅ N/A - Mudanças não requerem documentação                                         
                                                            
  ## 🧪 Checklist de Testes

  - [x] ✅ Criei ou atualizei testes E2E
  - [x] ✅ Todos os testes passam localmente — 18/18 IBGE UF
  - [x] ✅ Teste de CORS funciona corretamente                                              
  - [x] ✅ Testei casos de erro (404, 400, 500, etc.)                                       
  - [x] ✅ Testei casos de sucesso                                                          
                                                                                            
  ## 💻 Checklist de Código                                                                 
   
  - [x] ✅ Código segue os padrões do projeto (ESLint + Prettier)                           
  - [x] ✅ Não adicionei dependências desnecessárias ou pesadas
  - [x] ✅ Código não expõe credenciais ou informações sensíveis
  - [x] ✅ Tratei erros apropriadamente                                                     
  - [x] ✅ Usei Conventional Commits
                                                                                            
  ## 🚀 Checklist de Performance e Custos                                                   
  
  - [x] ✅ Não adicionei processamento pesado que aumenta custos                            
  - [x] ✅ Minimizei chamadas a APIs externas               

  ## 🔍 Como Testar

  1. `curl https://brasilapi.com.br/api/ibge/uf/v1/22` — hoje retorna 404, com o fix retorna
   200 (Piauí)
  2. `curl https://brasilapi.com.br/api/ibge/uf/v1/SJ` — hoje retorna `message: ""`, com o  
  fix retorna `message: "UF SJ não encontrada."`                                            
  3. `curl https://brasilapi.com.br/api/ibge/uf/v1/PI` — continua funcionando normalmente
                                                                                            
  ## 📎 Issues Relacionadas                                 
                                                                                            
  - Closes #798