### PR TITLE
test(b3): aceitar array vazio em testes de fundos

### DIFF
--- a/tests/b3-v1.test.js
+++ b/tests/b3-v1.test.js
@@ -75,9 +75,12 @@ describe('b3 v1 (E2E)', () => {
       const response = await axios.get(requestUrl);
 
       expect(response.status).toBe(200);
-      expect(response.data).toEqual(
-        expect.arrayContaining([validFundOutputSchema])
-      );
+      expect(Array.isArray(response.data)).toBe(true);
+      if (response.data.length > 0) {
+        expect(response.data).toEqual(
+          expect.arrayContaining([validFundOutputSchema])
+        );
+      }
     });
 
     test('Lista tickers de fundos tipo FIAGRO-FIP', async () => {
@@ -85,9 +88,12 @@ describe('b3 v1 (E2E)', () => {
       const response = await axios.get(requestUrl);
 
       expect(response.status).toBe(200);
-      expect(response.data).toEqual(
-        expect.arrayContaining([validFundOutputSchema])
-      );
+      expect(Array.isArray(response.data)).toBe(true);
+      if (response.data.length > 0) {
+        expect(response.data).toEqual(
+          expect.arrayContaining([validFundOutputSchema])
+        );
+      }
     });
 
     test('Lista tickers de fundos tipo FIP', async () => {
@@ -95,9 +101,12 @@ describe('b3 v1 (E2E)', () => {
       const response = await axios.get(requestUrl);
 
       expect(response.status).toBe(200);
-      expect(response.data).toEqual(
-        expect.arrayContaining([validFundOutputSchema])
-      );
+      expect(Array.isArray(response.data)).toBe(true);
+      if (response.data.length > 0) {
+        expect(response.data).toEqual(
+          expect.arrayContaining([validFundOutputSchema])
+        );
+      }
     });
 
     test('Lista tickers de fundos tipo FIA', async () => {
@@ -105,9 +114,12 @@ describe('b3 v1 (E2E)', () => {
       const response = await axios.get(requestUrl);
 
       expect(response.status).toBe(200);
-      expect(response.data).toEqual(
-        expect.arrayContaining([validFundOutputSchema])
-      );
+      expect(Array.isArray(response.data)).toBe(true);
+      if (response.data.length > 0) {
+        expect(response.data).toEqual(
+          expect.arrayContaining([validFundOutputSchema])
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
## 📋 Descrição                             
                                          
  A B3 pode legitimamente retornar array vazio para tipos de fundos sem tickers
  listados (ex: `FIAGRO-FIDC`, `FIA`). Os testes usavam `arrayContaining([schema])`                                                
  que exige pelo menos 1 item, causando falso-positivo.
                                                                                                                                   
  Agora os testes validam que a resposta é um array válido e só verificam o schema                                               
  dos itens quando há dados.                                                                                                       
                                                                                                                                   
  ## 🎯 Tipo de Mudança                                                                                                            
                                                                                                                                   
  - [x] ✅ Testes (adiciona ou corrige testes)                                                                                     
                                                                                                                                 
  ## ⚠️  Checklist de Compatibilidade (CRÍTICO)
                                                                                                                                   
  - [x] ✅ Não remove campos de respostas de API existentes
  - [x] ✅ Não renomeia campos de respostas de API existentes                                                                      
  - [x] ✅ Não muda tipos de dados de campos existentes                                                                          
  - [x] ✅ Não muda o formato de URLs de endpoints existentes                                                                      
  - [x] ✅ Não muda códigos de status HTTP de endpoints existentes
  - [x] ✅ Se fez mudanças incompatíveis, criei uma nova versão                                                                    
                                                                                                                                   
  ## 📚 Checklist de Documentação             
                                                                                                                                   
  - [x] ✅ N/A - Mudanças não requerem documentação                                                                                
                                                                                                                                   
  ## 🧪 Checklist de Testes                                                                                                        
                                                                                                                                   
  - [x] ✅ Criei ou atualizei testes E2E                                                                                         
  - [x] ✅ Todos os testes passam localmente (`npm test`) — 40/40 B3                                                               
  - [x] ✅ Código segue os padrões do projeto (ESLint + Prettier)                                                                
  - [x] ✅ Usei Conventional Commits                                                                                               
                                          
  ## 🚀 Checklist de Performance e Custos                                                                                          
                                                                                                                                   
  - [x] ✅ Não adicionei processamento pesado que aumenta custos
                                                                                                                                   
  ## 🔍 Como Testar                                                                                                              
                                                                                                                                   
  1. `npm test` — testes B3 passam independente de haver tickers dos tipos FIAGRO-FIDC e FIA                                       
                                                                                            
  ## 📎 Issues Relacionadas                                                                                                        
                                                                                                                                 
  - Closes #800