### PR TITLE
fix(cambio): corrige busca recursiva por dia útil

### DIFF
--- a/pages/api/cambio/v1/cotacao/[moeda]/[data].js
+++ b/pages/api/cambio/v1/cotacao/[moeda]/[data].js
@@ -26,7 +26,7 @@ const getCurrencyExchangeByDate = async (initialDate, coin, count = 0) => {
   const values = await getCurrencyExchange(date, coin);
 
   if (values.length === 0) {
-    output = getCurrencyExchangeByDate(initialDate, count + 1);
+    output = await getCurrencyExchangeByDate(initialDate, coin, count + 1);
   } else {
     output = { values, date };
   }

--- a/pages/api/cambio/v1/cotacao/[moeda]/[data].js
+++ b/pages/api/cambio/v1/cotacao/[moeda]/[data].js
@@ -102,7 +102,7 @@ const Action = async (request, response) => {
     const cotacoes = output.values;
     date = output.date;
 
-    if (output.length === 0) {
+    if (cotacoes.length === 0) {
       throw new BadRequestError({
         message: 'Não foi possível encontrar cotação para a data informada',
         type: 'no_data_error',


### PR DESCRIPTION
Atende à #734. As issues #704, #706 e #707 também são contempladas — são variantes do mesmo problema (29/02 em ano não bissexto, dia 32+ ajustado silenciosamente e mês 13 causando timeout) e ficam cobertas pelo `validateDateComponents` em `services/date.js`.

Durante a investigação, identifiquei dois bugs em `pages/api/cambio/v1/cotacao/[moeda]/[data].js`:

- Em `getCurrencyExchangeByDate`, a chamada recursiva não repassava o argumento `coin`, fazendo a recursão buscar cotação com moeda inválida.
- Em `Action`, a verificação `output.length === 0` testa propriedade inexistente no objeto `{ values, date }` retornado pela função, então o erro `NO_DATA_FOUND` nunca era lançado.

A validação de componentes de data (mês 00, dia 32, 30-fev, 29-fev em ano não bissexto, etc.) já estava implementada em `services/date.js` e segue funcionando. Os testes em `tests/cambio-v1.test.js` continuam passando (16/16).