### PR TITLE
fix(ibge): aceita código numérico em /ibge/uf/v1/:code

### DIFF
--- a/tests/ibge-uf-v1.test.js
+++ b/tests/ibge-uf-v1.test.js
@@ -48,7 +48,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual({
+    expect(response.data).toMatchObject({
       id: 22,
       sigla: expect.any(String),
       nome: expect.any(String),
@@ -58,6 +58,8 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         nome: expect.any(String),
       }),
       capital: expect.any(String),
+      populacao_estimada: expect.any(Number),
+      periodo: expect.any(String),
     });
   });
 
@@ -99,7 +101,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual({
+    expect(response.data).toMatchObject({
       id: 42,
       sigla: expect.any(String),
       nome: expect.any(String),
@@ -109,6 +111,8 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         nome: expect.any(String),
       }),
       capital: expect.any(String),
+      populacao_estimada: expect.any(Number),
+      periodo: expect.any(String),
     });
     expect(response.data.capital).toBe('Florianópolis');
   });
@@ -118,7 +122,7 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
     const response = await axios.get(requestUrl);
 
     expect(response.status).toBe(200);
-    expect(response.data).toEqual({
+    expect(response.data).toMatchObject({
       id: 22,
       sigla: expect.any(String),
       nome: expect.any(String),
@@ -128,6 +132,8 @@ describeIf(shouldSkipTests)('/ibge/uf/v1 (E2E)', () => {
         nome: expect.any(String),
       }),
       capital: expect.any(String),
+      populacao_estimada: expect.any(Number),
+      periodo: expect.any(String),
     });
     expect(response.data.capital).toBe('Teresina');
   });

--- a/util/mapUfToUfCode.js
+++ b/util/mapUfToUfCode.js
@@ -45,7 +45,7 @@ export default function mapUfToUfCode(uf) {
 
     const ufCode = UF_CODE_MAPPER[input];
     if(!ufCode){
-        throw new NotFoundError(`UF ${uf} não encontrado`);
+        throw new NotFoundError({ message: 'UF não encontrada.' });
     }
 
     return ufCode;

--- a/util/mapUfToUfCode.js
+++ b/util/mapUfToUfCode.js
@@ -31,13 +31,19 @@ const UF_CODE_MAPPER = {
 }
 
 /**
- * Map UF (e.g. SP) to UF Code Id on IBGE API
- * @param {string} uf String UF short
+ * Map UF (e.g. SP) to UF Code Id on IBGE API.
+ * Aceita também o próprio código numérico do IBGE (e.g. 22) e o devolve inalterado.
+ * @param {string|number} uf Sigla da UF ou código numérico do IBGE
  * @returns {number} UF Code
  */
 export default function mapUfToUfCode(uf) {
-    uf = uf.toUpperCase();
-    let ufCode = UF_CODE_MAPPER[uf];
+    const input = String(uf).toUpperCase();
+
+    if (/^\d+$/.test(input) && Object.values(UF_CODE_MAPPER).includes(Number(input))) {
+        return Number(input);
+    }
+
+    const ufCode = UF_CODE_MAPPER[input];
     if(!ufCode){
         throw new NotFoundError(`UF ${uf} não encontrado`);
     }


### PR DESCRIPTION
Atende à #798.

O endpoint `/api/ibge/uf/v1/:code` foi projetado para aceitar tanto sigla (`PI`) quanto código numérico do IBGE (`22`), mas retornava 404 sempre que o parâmetro era um código numérico. A causa está em `util/mapUfToUfCode.js`, que só consultava o mapa por sigla — quando recebia `"22"`, não encontrava no `UF_CODE_MAPPER` e lançava `NotFoundError`, fazendo o `Promise.all` do handler rejeitar antes da resposta válida de `getUfByCode`.

Mudanças:

- `util/mapUfToUfCode.js`: passa a aceitar tanto sigla (`PI`) quanto código numérico do IBGE (`22`); retorna o próprio código quando ele já é um valor válido do `UF_CODE_MAPPER`.
- `util/mapUfToUfCode.js`: corrige a instanciação do `NotFoundError` que estava sendo chamada com string em vez de objeto, fazendo o campo `message` chegar vazio na resposta. Agora usa a mensagem canônica `"UF não encontrada."`, alinhada com o `throw` explícito do handler.
- `tests/ibge-uf-v1.test.js`: troca `toEqual` por `toMatchObject` nas asserções positivas e cobre os campos `populacao_estimada` e `periodo`, que já constam no schema OpenAPI (`pages/docs/doc/ibge.json`) desde a introdução de `getUfEstimatePopulationByCode`.

Validação local com `npm test -- tests/ibge-uf-v1.test.js`: 18/18 passando. Bateria cURL cobrindo `/22`, `/PI`, `/sc` (200), `/99`, `/SJ` (404 com mensagem padronizada) e `/v1` (listagem) também passou.