### PR TITLE
fix(cptec): valida days inteiro em /clima/previsao/{cityCode}/{days}

### DIFF
--- a/pages/api/cptec/v1/clima/previsao/[cityCode]/[days].js
+++ b/pages/api/cptec/v1/clima/previsao/[cityCode]/[days].js
@@ -17,6 +17,14 @@ const action = async (request, response) => {
     });
   }
 
+  if (!Number.isInteger(Number(days))) {
+    throw new BadRequestError({
+      message: 'Quantidade de dias inválida, informe um valor inteiro',
+      type: 'request_error',
+      name: 'INVALID_NUMBER_OF_DAYS',
+    });
+  }
+
   if (days < MIN_DAYS || days > MAX_WEATHER_DAYS) {
     throw new BadRequestError({
       message: 'Quantidade de dias inválida (mínimo 1 dia e máximo 14 dias)',

--- a/tests/cpetc/previsao-v1.test.js
+++ b/tests/cpetc/previsao-v1.test.js
@@ -126,6 +126,23 @@ describeIf(shouldSkipTests)('weather prediction v1 (E2E)', () => {
         });
       }
     });
+
+    test('GET /api/cptec/v1/clima/previsao/:cityCode/:days (Non-integer days: 2.5)', async () => {
+      const requestUrl = `${global.SERVER_URL}/api/cptec/v1/clima/previsao/999/2.5`;
+
+      try {
+        await axios.get(requestUrl);
+      } catch (error) {
+        const { response } = error;
+
+        expect(response.status).toBe(400);
+        expect(response.data).toMatchObject({
+          message: 'Quantidade de dias inválida, informe um valor inteiro',
+          type: 'request_error',
+          name: 'INVALID_NUMBER_OF_DAYS',
+        });
+      }
+    });
   });
   describe('Route WITH lat long', () => {
     test('GET prevision of campina - sp', async () => {


### PR DESCRIPTION
Estende ao endpoint `/api/cptec/v1/clima/previsao/{cityCode}/{days}` a mesma validação de `Number.isInteger` que o #717 introduziu em `/api/cptec/v1/ondas/{cityCode}/{days}`. Antes deste PR, valores decimais como `2.5` eram aceitos silenciosamente e o handler chamava o serviço com um número não-inteiro.

Comportamento antes:

```bash
curl http://localhost:3000/api/cptec/v1/clima/previsao/244/2.5
# → 200 OK com dados de São Paulo
```

Comportamento depois:

```bash
curl http://localhost:3000/api/cptec/v1/clima/previsao/244/2.5
# → 400 {"message":"Quantidade de dias inválida, informe um valor inteiro","type":"request_error","name":"INVALID_NUMBER_OF_DAYS"}
```

Mudanças:

- `pages/api/cptec/v1/clima/previsao/[cityCode]/[days].js`: novo bloco `Number.isInteger(Number(days))` espelhando o handler de `/ondas`.
- `tests/cpetc/previsao-v1.test.js`: novo teste cobrindo o caso de `days = 2.5`, espelhando o teste adicionado pelo #717 em `ondas-v1.test.js`.

Observação: a suíte `tests/cpetc/*` tem um padrão de health check que avalia `describe.skip` em module load (antes do `beforeAll` resolver), o que faz toda a suíte CPTEC ser skipada na maioria dos ambientes. Esse comportamento é pré-existente e foi herdado pelo `ondas-v1.test.js` no #717. Validação ponta a ponta foi feita via cURL local; o teste novo fica como documentação de intenção e roda assim que o pattern de skip for endereçado.

Relacionado a #729 (que cobre o caso simétrico em `/ondas`, já resolvido pelo #717).