### PR TITLE
fix(ibge-uf): accept numeric IBGE code in mapUfToUfCode

### DIFF
--- a/util/mapUfToUfCode.js
+++ b/util/mapUfToUfCode.js
@@ -31,16 +31,23 @@ const UF_CODE_MAPPER = {
 }
 
 /**
- * Map UF (e.g. SP) to UF Code Id on IBGE API
- * @param {string} uf String UF short
+ * Map UF sigla (e.g. SP) or numeric IBGE code (e.g. 35) to UF Code Id on IBGE API
+ * @param {string|number} uf UF sigla or numeric IBGE code
  * @returns {number} UF Code
  */
 export default function mapUfToUfCode(uf) {
-    uf = uf.toUpperCase();
-    let ufCode = UF_CODE_MAPPER[uf];
-    if(!ufCode){
-        throw new NotFoundError(`UF ${uf} não encontrado`);
+    const numeric = parseInt(uf, 10);
+    if (!isNaN(numeric) && String(numeric) === String(uf)) {
+        const isValid = Object.values(UF_CODE_MAPPER).includes(numeric);
+        if (!isValid) {
+            throw new NotFoundError(`UF ${uf} não encontrado`);
+        }
+        return numeric;
     }
 
+    const ufCode = UF_CODE_MAPPER[String(uf).toUpperCase()];
+    if (!ufCode) {
+        throw new NotFoundError(`UF ${uf} não encontrado`);
+    }
     return ufCode;
 }


### PR DESCRIPTION
## Problema

O endpoint `/api/ibge/uf/v1/:code` aceita sigla (`PI`) mas retorna 404 quando um codigo numerico IBGE (`22`) e passado, mesmo sendo um formato valido e documentado.

**Reproduzir:**
```bash
curl https://brasilapi.com.br/api/ibge/uf/v1/PI  # 200 OK
curl https://brasilapi.com.br/api/ibge/uf/v1/22  # 404 (errado)
```

## Causa

`mapUfToUfCode` em `util/mapUfToUfCode.js` busca o input como chave no `UF_CODE_MAPPER` (ex: `UF_CODE_MAPPER["22"]`), que retorna `undefined`. Isso lanca `NotFoundError`, que faz o `Promise.all` no handler rejeitar a request inteira.

## Fix

Detectar input numerico e validar contra os valores do mapa, retornando diretamente quando valido. Lookup por sigla permanece inalterado.

```js
const numeric = parseInt(uf, 10);
if (!isNaN(numeric) && String(numeric) === String(uf)) {
    const isValid = Object.values(UF_CODE_MAPPER).includes(numeric);
    if (!isValid) throw new NotFoundError(...);
    return numeric;
}
```

O teste `Utilizando um Codigo valido: 22` em `tests/ibge-uf-v1.test.js` ja esperava `status 200` para esse caso e estava falhando.

Closes #798