### PR TITLE
Valida formato de CEP antes de consultar provedores

### DIFF
--- a/services/cep/cep.js
+++ b/services/cep/cep.js
@@ -11,8 +11,21 @@ function onlyDigits(cep) {
 }
 
 function isValidCep(cep) {
+  return /^\d{8}$/.test(cep) || /^\d{5}-\d{3}$/.test(cep);
+}
+
+function getCepValidationMessage(cep) {
   const cleanCep = onlyDigits(cep);
-  return cleanCep.length === CEP_LENGTH;
+
+  if (cleanCep.length < CEP_LENGTH) {
+    return `CEP informado possui menos do que ${CEP_LENGTH} caracteres.`;
+  }
+
+  if (cleanCep.length > CEP_LENGTH) {
+    return `CEP informado possui mais do que ${CEP_LENGTH} caracteres.`;
+  }
+
+  return 'CEP informado deve conter apenas números ou seguir o formato 00000-000.';
 }
 
 async function fetchOpenCep(cep) {
@@ -51,17 +64,12 @@ export async function fetchCep(cep) {
   const cleanCep = onlyDigits(cep);
 
   if (!isValidCep(cep)) {
-    const errorMessage =
-      cleanCep.length < CEP_LENGTH
-        ? `CEP informado possui menos do que ${CEP_LENGTH} caracteres.`
-        : `CEP informado possui mais do que ${CEP_LENGTH} caracteres.`;
-
     throw new CepPromiseError({
       message: `CEP deve conter exatamente ${CEP_LENGTH} caracteres.`,
       type: 'validation_error',
       errors: [
         {
-          message: errorMessage,
+          message: getCepValidationMessage(cep),
           service: 'cep_validation',
         },
       ],

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -104,6 +104,30 @@ describe('/cep/v1 (E2E)', () => {
       });
     }
   });
+  test('Utilizando um CEP com separador em posicao invalida: 002123-25', async () => {
+    expect.assertions(2);
+    const requestUrl = `${global.SERVER_URL}/api/cep/v1/002123-25`;
+
+    try {
+      await axios.get(requestUrl);
+    } catch (error) {
+      const { response } = error;
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual({
+        name: 'CepPromiseError',
+        message: 'CEP deve conter exatamente 8 caracteres.',
+        type: 'validation_error',
+        errors: [
+          {
+            message:
+              'CEP informado deve conter apenas números ou seguir o formato 00000-000.',
+            service: 'cep_validation',
+          },
+        ],
+      });
+    }
+  });
 });
 
 testCorsForRoute('/api/cep/v1/05010000');

--- a/tests/cep-v2.test.js
+++ b/tests/cep-v2.test.js
@@ -164,6 +164,30 @@ describe('/cep/v2 (E2E)', () => {
       },
     });
   });
+  test('Utilizando um CEP com separador em posicao invalida: 002123-25', async () => {
+    expect.assertions(2);
+    const requestUrl = `${global.SERVER_URL}/api/cep/v2/002123-25`;
+
+    try {
+      await axios.get(requestUrl);
+    } catch (error) {
+      const { response } = error;
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual({
+        name: 'CepPromiseError',
+        message: 'CEP deve conter exatamente 8 caracteres.',
+        type: 'validation_error',
+        errors: [
+          {
+            message:
+              'CEP informado deve conter apenas números ou seguir o formato 00000-000.',
+            service: 'cep_validation',
+          },
+        ],
+      });
+    }
+  });
 });
 
 testCorsForRoute('/api/cep/v2/14096180');


### PR DESCRIPTION
## O que foi feito
- Valida o formato do CEP antes de consultar os provedores externos.
- Mantém suporte a CEP com 8 dígitos e ao formato 00000-000.
- Retorna validation_error para entradas com hífen em posição inválida, como 002123-25.
- Adiciona cobertura para as rotas /cep/v1 e /cep/v2.

Closes #731

## Validação
- npm run test -- tests/cep-v1.test.js tests/cep-v2.test.js
- npx eslint services/cep/cep.js tests/cep-v1.test.js tests/cep-v2.test.js
- git diff --check
