### PR TITLE
fix(ibge/uf): accept numeric IBGE codes in mapUfToUfCode

### DIFF
--- a/util/mapUfToUfCode.js
+++ b/util/mapUfToUfCode.js
@@ -30,6 +30,10 @@ const UF_CODE_MAPPER = {
   "DF": 53,
 }
 
+const CODE_TO_UF = Object.fromEntries(
+  Object.entries(UF_CODE_MAPPER).map(([uf, code]) => [code, uf])
+)
+
 /**
  * Map UF (e.g. SP) to UF Code Id on IBGE API
  * @param {string} uf String UF short
@@ -38,7 +42,16 @@ const UF_CODE_MAPPER = {
 export default function mapUfToUfCode(uf) {
     uf = uf.toUpperCase();
     let ufCode = UF_CODE_MAPPER[uf];
-    if(!ufCode){
+
+    if (!ufCode && /^\d+$/.test(uf)) {
+        const code = parseInt(uf, 10);
+        const ufFromCode = CODE_TO_UF[code];
+        if (ufFromCode) {
+            ufCode = code;
+        }
+    }
+
+    if (!ufCode) {
         throw new NotFoundError(`UF ${uf} não encontrado`);
     }
 


### PR DESCRIPTION
## Problema

O endpoint `/api/ibge/uf/v1/:code` foi projetado para aceitar tanto sigla (`PI`) quanto código numérico IBGE (`22`), mas retorna 404 quando um código numérico é passado.

## Causa raiz

`getUfEstimatePopulationByCode` chama `mapUfToUfCode` internamente, que só aceitava siglas (PI, SC). Quando recebia `22`, não encontrava no mapa e lançava `NotFoundError$, fazendo o `Promise.all` no handler rejeitar e a request inteira retornar 404.

## Solução

Adiciona um reverse lookup (`CODE_TO_UF`) derivado do `UF_CODE_MAPPER`. Quando a entrada não é encontrada como sigla mas é um valor numérico, faz a busca reversa para resolver a sigla correspondente e retorna o código numérico esperado.

Closes #798