### PR TITLE
fix(ncm): handle both old and new field naming for ato fields

### DIFF
--- a/services/sefaz/index.js
+++ b/services/sefaz/index.js
@@ -12,9 +12,12 @@ function parseObject(obj) {
   );
 
   const {
-    tipo_ato_ini: tipoAtoIni,
-    numero_ato_ini: numeroAtoIni,
-    ano_ato_ini: anoAtoIni,
+    tipo_ato_ini: tipoAtoOld,
+    numero_ato_ini: numeroAtoOld,
+    ano_ato_ini: anoAtoOld,
+    tipo_ato: tipoAtoNew,
+    numero_ato: numeroAtoNew,
+    ano_ato: anoAtoNew,
     data_inicio: dataInicio,
     data_fim: dataFim,
     ...rest
@@ -24,9 +27,9 @@ function parseObject(obj) {
     ...rest,
     data_inicio: formatDate(dataInicio),
     data_fim: formatDate(dataFim),
-    tipo_ato: tipoAtoIni,
-    numero_ato: numeroAtoIni,
-    ano_ato: anoAtoIni,
+    tipo_ato: tipoAtoNew ?? tipoAtoOld,
+    numero_ato: numeroAtoNew ?? numeroAtoOld,
+    ano_ato: anoAtoNew ?? anoAtoOld,
   };
 
   return newObj;


### PR DESCRIPTION
## Problema

O endpoint `/api/ncm/v1/:code` está omitindo `tipo_ato`, `numero_ato` e `ano_ato` da resposta.

## Causa raiz

O `parseObject` esperava `tipo_ato_ini` / `numero_ato_ini` / `ano_ato_ini` (formato antigo do upstream), mas o Siscomex mudou para `tipo_ato` / `numero_ato` / `ano_ato`. O fallback `ncmList.json` também usa o novo formato.

Quando o limite de taxa do upstream (3 req/h) era atingido, o fallback produzia `undefined` porque os campos `_ini` não existiam.

## Solução

Faz o destructuring de ambas as convenções de nomenclatura, preferindo o novo formato com nullish coalescing (`??`) como fallback.

Closes #796