### PR TITLE
fix(docs): corrige schema de CEP no CNPJ

### DIFF
--- a/pages/docs/doc/cnpj.json
+++ b/pages/docs/doc/cnpj.json
@@ -82,8 +82,7 @@
             "description": "Sigla da unidade da federação em que se encontra o estabelecimento. Quando o estabelecimento estiver localizado no exterior, o campo será preenchido com 'EX'."
           },
           "cep": {
-            "type": "integer",
-            "format": "int32",
+            "type": "string",
             "description": "Código de endereçamento postal referente ao logradouro no qual o estabelecimento esta localizado"
           },
           "qsa": {


### PR DESCRIPTION
* **Corrige** o schema de `cnpj.json`, alterando o tipo do campo `cep` de `integer` para `string`, conforme o retorno real da API.
* **Mantém** o campo `capital_social` como `integer`, pois a API retorna esse valor como um número inteiro.
* **Valida** manualmente as respostas das APIs de **CNPJ** e **CEP**, garantindo consistência entre a documentação, os exemplos e os schemas.

### ✅ Checklist

* [x] **Corrigido** o tipo do campo `cep` em `cnpj.json` (`integer` → `string`)
* [x] **Confirmado** que `capital_social` é retornado como `integer`
* [x] **Validada** a resposta da API de **CNPJ**
* [x] **Validada** a resposta da API de **CEP**
* [x] **Verificadas** inconsistências entre a documentação, os exemplos e os schemas