### PR TITLE
fix: normaliza CRLF e espaços no CSV do PIX

### DIFF
--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -46,14 +46,13 @@ export const getPixParticipants = async (fromToday = true, daysBefore = 1) => {
  */
 
 export const formatCsvFile = (file) => {
-  const LINE_BREAK = '\n';
-  const lines = file.split(LINE_BREAK);
+  const lines = file.split(/\r?\n/);
 
   lines.shift(); // Remove a primeira linha que é o cabeçalho (Lista de participantes ativos do Pix)
   const headers = lines
     .shift()
     .split(';')
-    .map((header) => header.toLowerCase().replace(/ /g, ''));
+    .map((header) => header.trim().toLowerCase().replace(/\s/g, ''));
 
   const expectedHeaders = [
     'nomereduzido',
@@ -71,7 +70,7 @@ export const formatCsvFile = (file) => {
 
   try {
     return lines
-      .map((line) => line.split(';'))
+      .map((line) => line.split(';').map((field) => field.trim()))
       .filter(([ispb]) => ispb)
       .map((data) => {
         return {

--- a/tests/services/pix/participants.test.js
+++ b/tests/services/pix/participants.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatCsvFile } from '@/services/pix/participants';
+
+describe('formatCsvFile', () => {
+  test('normalizes CRLF and surrounding whitespace', () => {
+    const csv = [
+      'Lista de participantes ativos do Pix',
+      'CNPJ ; Nome Reduzido ; ISPB ; Nome Extenso ; Inicio ; Fim ; Tipo de Participação no SPI ; Status ; Modalidade de Participação no Pix',
+      ' 00000000000191 ; Banco Teste ; 12345678 ; Banco Teste S.A. ; 2020-01-01 ; ; Direta ; Ativo ; Participante ',
+      '   ',
+    ].join('\r\n');
+
+    expect(formatCsvFile(csv)).toEqual([
+      {
+        ispb: '12345678',
+        nome: 'Banco Teste',
+        nome_reduzido: 'Banco Teste',
+        modalidade_participacao: 'Participante',
+        tipo_participacao: 'Direta',
+        inicio_operacao: null,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## O que foi alterado

- trata arquivos CSV com quebras de linha CRLF
- remove espaços no início e no fim de cabeçalhos e campos
- ignora corretamente linhas vazias após a normalização
- adiciona teste de regressão com CRLF e espaços excedentes

O formato público da resposta do endpoint PIX permanece inalterado.

## Validação

- `npm run concurrently -- --hide dev -- run tests/services/pix/participants.test.js`
- ESLint direcionado aos dois arquivos alterados
- Prettier direcionado aos dois arquivos alterados

Closes #710