### PR TITLE
fix: remove propriedade 'public' do vercel.json (deploys quebrados)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -43,8 +43,8 @@ function findLocationByCep(locations, cep) {
   }
 
   return locationsWithPostCodes.find(
-    (item) => onlyDigits(item.address.postcode).slice(0, 5) ===
-      cleanedCep.slice(0, 5)
+    (item) =>
+      onlyDigits(item.address.postcode).slice(0, 5) === cleanedCep.slice(0, 5)
   );
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "public": true,
 	"functions": {
 		"pages/api/**": {
 			"memory": 256,


### PR DESCRIPTION
## Problema
**Produção está parada no build de 14/04/2026** — todos os deploys recentes falham com:
`The vercel.json schema validation failed: should NOT have additional property 'public'`

A Vercel parou de aceitar a propriedade `public` no schema do vercel.json (existente desde 2020). Resultado: nenhum merge chega à produção.

## Fix
Remove `"public": true` do vercel.json (1 linha). Deployments de projetos sem proteção continuam públicos por padrão.

## Impacto
- Destrava o deploy automático da main
- Põe em produção os 12 PRs mergeados hoje (IBGE, B3, NCM, câmbio, PIX, CEP, CPTEC, docs)