### PR TITLE
chore: sobe Node para 24.x no engines (deprecation Vercel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Vamos transformar o Brasil em uma API?",
   "engines": {
     "npm": ">=10",
-    "node": ">=20 <22"
+    "node": "24.x"
   },
   "dependencies": {
     "@djpfs/react-vlibras": "2.0.2",


### PR DESCRIPTION
## Problema
A Vercel avisou no build: `Node.js version 20.x is deprecated. Deployments created on or after 2026-10-01 will fail to build. Please set engines: { node: 24.x }`.

## Mudança
`engines.node`: `>=20 <22` → `24.x` (recomendação oficial da Vercel).

## Validação
- Build completo (`npm install && npm run build`) executado com **node:24** via Docker: ✅ passa (Next 12 compila sem erros)
- O deploy preview da Vercel com Node 24 confirmará no runtime real