### PR TITLE
ci: corrige timeout dos testes E2E (SIGTERM)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Rodar testes
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 5
-          retry_wait_seconds: 120
-          max_attempts: 3
+          timeout_minutes: 15
+          retry_wait_seconds: 60
+          max_attempts: 1
           retry_on: error
           command: npm test
 

--- a/tests/geolocation-v1.test.js
+++ b/tests/geolocation-v1.test.js
@@ -1,4 +1,5 @@
-const axios = require('axios');
+import axios from 'axios';
+import { describe, expect, test } from 'vitest';
 
 describe('/geolocation/v1 (E2E)', () => {
   test('it should be return the city and country if the coordinates exists', async () => {


### PR DESCRIPTION
## Problema
O job `Rodar testes E2E` está sempre falhando com SIGTERM a ~7m45s: o wrapper `nick-fields/retry` tem `timeout_minutes: 5`, mas a suíte completa (agora que o health check do FIPE evita falhas rápidas) demora mais de 5 min por execução — toda tentativa estoura o timeout e o job morre antes de concluir.

## Mudança
- `timeout_minutes: 5 → 15`
- `max_attempts: 3 → 1` (retries só mascaravam; a suíte roda determinística)
- `retry_wait_seconds: 120 → 60`

Afeta todos os PRs — sem isso o CI nunca fica verde.