### PR TITLE
test(geolocation): corrige imports vitest (CI quebrado)

### DIFF
--- a/tests/geolocation-v1.test.js
+++ b/tests/geolocation-v1.test.js
@@ -1,4 +1,5 @@
-const axios = require('axios');
+import axios from 'axios';
+import { describe, expect, test } from 'vitest';
 
 describe('/geolocation/v1 (E2E)', () => {
   test('it should be return the city and country if the coordinates exists', async () => {


### PR DESCRIPTION
O teste do #133 (geolocation) foi mergeado com `require()` e sem import do vitest — `ReferenceError: describe is not defined` derruba o E2E de **todos** os PRs. Fix: `import { describe, expect, test } from 'vitest'` + ESM.