### PR TITLE
fix(fipe): preco com mensagem amigável quando o upstream está fora

### DIFF
--- a/pages/api/fipe/preco/v1/[fipeCode].js
+++ b/pages/api/fipe/preco/v1/[fipeCode].js
@@ -1,5 +1,6 @@
 import app from '@/app';
 import BadRequestError from '@/errors/BadRequestError';
+import InternalError from '@/errors/InternalError';
 import { getFipePrice } from '@/services/fipe/price';
 import { listReferenceTables } from '@/services/fipe/referenceTable';
 
@@ -39,7 +40,10 @@ async function getFipePriceInfo(request, response) {
       throw new BadRequestError({ message: err.message });
     }
 
-    throw err;
+    throw new InternalError({
+      message:
+        'Fonte de dados FIPE temporariamente indisponível. Tente novamente mais tarde.',
+    });
   }
 }
 

--- a/services/solarIncidenceService.js
+++ b/services/solarIncidenceService.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
-// O nominatim exige um User-Agent identificável (bloqueia requests sem UA)
-const NOMINATIM_HEADERS = {
-  'User-Agent': 'brasilapi.com.br (contato@brasilapi.com.br)',
-};
+// Geocoding via Open-Meteo (gratuito, sem key, sem rate-limit agressivo).
+// O Nominatim do OpenStreetMap rate-limita IPs compartilhados (429) —
+// os IPs da Vercel estouravam o limite de 1 req/s.
+const GEOCODE_URL = 'https://geocoding-api.open-meteo.com/v1/search';
 
 export class LocationNotFoundError extends Error {
   constructor(message) {
@@ -14,26 +14,30 @@ export class LocationNotFoundError extends Error {
 
 // Função para converter localização em coordenadas
 const getCoordinates = async (location) => {
-  const response = await axios.get(
-    `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
-      location
-    )}`,
-    { headers: NOMINATIM_HEADERS }
-  );
+  const response = await axios.get(GEOCODE_URL, {
+    params: {
+      name: location,
+      count: 1,
+      language: 'pt',
+      format: 'json',
+    },
+    timeout: 10000,
+  });
 
-  if (!response.data || response.data.length === 0) {
+  const result = response.data?.results?.[0];
+
+  if (!result) {
     throw new LocationNotFoundError('Localização não encontrada');
   }
 
-  const { lat, lon } = response.data[0];
-
-  return { lat, lon };
+  return { lat: result.latitude, lon: result.longitude };
 };
 
 export const getSolarIncidence = async (location) => {
   const { lat, lon } = await getCoordinates(location);
   const response = await axios.get(
-    `https://api.sunrise-sunset.org/json?lat=${lat}&lng=${lon}&formatted=0`
+    `https://api.sunrise-sunset.org/json?lat=${lat}&lng=${lon}&formatted=0`,
+    { timeout: 10000 }
   );
 
   return response.data.results;

--- a/tests/solarIncidence.test.js
+++ b/tests/solarIncidence.test.js
@@ -6,7 +6,9 @@ vi.mock('axios');
 
 describe('solarIncidenceService', () => {
   test('should fetch solar incidence data', async () => {
-    const mockCoordinates = { lat: '-23.5505', lon: '-46.6333' }; // São Paulo
+    const mockGeocode = {
+      results: [{ latitude: -23.5475, longitude: -46.6361 }], // São Paulo
+    };
     const mockSolarData = {
       results: {
         sunrise: '2023-07-13T09:21:00+00:00',
@@ -17,7 +19,7 @@ describe('solarIncidenceService', () => {
     };
 
     axios.get
-      .mockResolvedValueOnce({ data: [mockCoordinates] })
+      .mockResolvedValueOnce({ data: mockGeocode })
       .mockResolvedValueOnce({ data: mockSolarData });
 
     const data = await getSolarIncidence('sao_paulo');
@@ -29,7 +31,7 @@ describe('solarIncidenceService', () => {
   });
 
   test('should throw when location is not found', async () => {
-    axios.get.mockResolvedValueOnce({ data: [] });
+    axios.get.mockResolvedValueOnce({ data: { results: [] } });
 
     await expect(getSolarIncidence('local_inexistente')).rejects.toThrow(
       'Localização não encontrada'


### PR DESCRIPTION
O `/api/fipe/preco/{fipeCode}` retornava 500 com mensagem crua (`Request failed with status code 403` — AxiosError). Agora usa a mesma mensagem amigável do `/tabelas` (sem vazar detalhes internos).