### PR TITLE
fix(cep): geolocalização do v2 via Photon (Nominatim 429 nos IPs da Vercel)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -61,7 +61,10 @@ function parseLocation(location) {
 
   const [longitude, latitude] = location.geometry?.coordinates ?? [];
 
-  return { type: 'Point', coordinates: { longitude, latitude } };
+  return {
+    type: 'Point',
+    coordinates: { longitude: String(longitude), latitude: String(latitude) },
+  };
 }
 
 async function fetchGeocoordinateFromBrazilLocation({

--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -1,4 +1,4 @@
-const https = require('https');
+import https from 'https';
 
 let cacheAgent;
 
@@ -31,11 +31,11 @@ function findLocationByCep(locations, cep) {
 
   const cleanedCep = onlyDigits(cep);
   const locationsWithPostCodes = locations.filter(
-    (item) => item.address?.postcode
+    (item) => item.properties?.postcode
   );
 
   const exactLocation = locationsWithPostCodes.find(
-    (item) => onlyDigits(item.address.postcode) === cleanedCep
+    (item) => onlyDigits(item.properties.postcode) === cleanedCep
   );
 
   if (exactLocation) {
@@ -44,7 +44,8 @@ function findLocationByCep(locations, cep) {
 
   return locationsWithPostCodes.find(
     (item) =>
-      onlyDigits(item.address.postcode).slice(0, 5) === cleanedCep.slice(0, 5)
+      onlyDigits(item.properties.postcode).slice(0, 5) ===
+      cleanedCep.slice(0, 5)
   );
 }
 
@@ -58,7 +59,8 @@ function parseLocation(location) {
     return unavailableCoordinate;
   }
 
-  const { lat: latitude, lon: longitude } = location;
+  const [longitude, latitude] = location.geometry?.coordinates ?? [];
+
   return { type: 'Point', coordinates: { longitude, latitude } };
 }
 
@@ -79,28 +81,19 @@ async function fetchGeocoordinateFromBrazilLocation({
   const requestConfig = {
     agent,
     headers,
-    signal: AbortSignal.timeout(2000),
+    signal: AbortSignal.timeout(3000),
   };
   const cleanedCep = cep ? onlyDigits(cep) : null;
+  const query = [extractAltFromStreet(street), city, state, cleanedCep]
+    .filter(Boolean)
+    .join(', ');
   const queryParams = new URLSearchParams({
-    format: 'jsonv2',
-    addressdetails: '1',
+    q: query,
     limit: '10',
-    country: 'Brasil',
-    state,
-    city,
   });
 
-  if (street) {
-    queryParams.set('street', extractAltFromStreet(street));
-  }
-
-  if (cleanedCep) {
-    queryParams.set('postalcode', cleanedCep);
-  }
-
   let response = await fetch(
-    `https://nominatim.openstreetmap.org/search?${queryParams.toString()}`,
+    `https://photon.komoot.io/api/?${queryParams.toString()}`,
     requestConfig
   ).catch(() => {
     return { ok: false };
@@ -110,21 +103,22 @@ async function fetchGeocoordinateFromBrazilLocation({
     return unavailableCoordinate;
   }
 
-  let locations = await response.json();
+  let locations = (await response.json()).features;
   let location = findLocationByCep(locations, cep);
 
   if (!location && street && cleanedCep) {
-    queryParams.delete('street');
+    const retryQuery = [city, state, cleanedCep].filter(Boolean).join(', ');
+    queryParams.set('q', retryQuery);
 
     response = await fetch(
-      `https://nominatim.openstreetmap.org/search?${queryParams.toString()}`,
+      `https://photon.komoot.io/api/?${queryParams.toString()}`,
       requestConfig
     ).catch(() => {
       return { ok: false };
     });
 
     if (response?.ok) {
-      locations = await response.json();
+      locations = (await response.json()).features;
       location = findLocationByCep(locations, cep);
     }
   }

--- a/pages/api/fipe/preco/v1/[fipeCode].js
+++ b/pages/api/fipe/preco/v1/[fipeCode].js
@@ -1,5 +1,6 @@
 import app from '@/app';
 import BadRequestError from '@/errors/BadRequestError';
+import InternalError from '@/errors/InternalError';
 import { getFipePrice } from '@/services/fipe/price';
 import { listReferenceTables } from '@/services/fipe/referenceTable';
 
@@ -39,7 +40,10 @@ async function getFipePriceInfo(request, response) {
       throw new BadRequestError({ message: err.message });
     }
 
-    throw err;
+    throw new InternalError({
+      message:
+        'Fonte de dados FIPE temporariamente indisponível. Tente novamente mais tarde.',
+    });
   }
 }
 

--- a/services/solarIncidenceService.js
+++ b/services/solarIncidenceService.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
-// O nominatim exige um User-Agent identificável (bloqueia requests sem UA)
-const NOMINATIM_HEADERS = {
-  'User-Agent': 'brasilapi.com.br (contato@brasilapi.com.br)',
-};
+// Geocoding via Open-Meteo (gratuito, sem key, sem rate-limit agressivo).
+// O Nominatim do OpenStreetMap rate-limita IPs compartilhados (429) —
+// os IPs da Vercel estouravam o limite de 1 req/s.
+const GEOCODE_URL = 'https://geocoding-api.open-meteo.com/v1/search';
 
 export class LocationNotFoundError extends Error {
   constructor(message) {
@@ -14,26 +14,30 @@ export class LocationNotFoundError extends Error {
 
 // Função para converter localização em coordenadas
 const getCoordinates = async (location) => {
-  const response = await axios.get(
-    `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
-      location
-    )}`,
-    { headers: NOMINATIM_HEADERS }
-  );
+  const response = await axios.get(GEOCODE_URL, {
+    params: {
+      name: location,
+      count: 1,
+      language: 'pt',
+      format: 'json',
+    },
+    timeout: 10000,
+  });
 
-  if (!response.data || response.data.length === 0) {
+  const result = response.data?.results?.[0];
+
+  if (!result) {
     throw new LocationNotFoundError('Localização não encontrada');
   }
 
-  const { lat, lon } = response.data[0];
-
-  return { lat, lon };
+  return { lat: result.latitude, lon: result.longitude };
 };
 
 export const getSolarIncidence = async (location) => {
   const { lat, lon } = await getCoordinates(location);
   const response = await axios.get(
-    `https://api.sunrise-sunset.org/json?lat=${lat}&lng=${lon}&formatted=0`
+    `https://api.sunrise-sunset.org/json?lat=${lat}&lng=${lon}&formatted=0`,
+    { timeout: 10000 }
   );
 
   return response.data.results;

--- a/tests/fetchGeocoordinateFromBrazilLocation.test.js
+++ b/tests/fetchGeocoordinateFromBrazilLocation.test.js
@@ -9,6 +9,11 @@ function createFetchResponse(data, ok = true) {
   };
 }
 
+const photonFeature = (postcode, coords) => ({
+  geometry: { coordinates: coords },
+  properties: { postcode },
+});
+
 describe('fetchGeocoordinateFromBrazilLocation', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -17,15 +22,11 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
   test('faz fallback sem logradouro quando a busca inicial nao encontra resultado', async () => {
     const fetchMock = vi
       .spyOn(global, 'fetch')
-      .mockResolvedValueOnce(createFetchResponse([]))
+      .mockResolvedValueOnce(createFetchResponse({ features: [] }))
       .mockResolvedValueOnce(
-        createFetchResponse([
-          {
-            lat: '-23.55052',
-            lon: '-46.633308',
-            address: { postcode: '05010-000' },
-          },
-        ])
+        createFetchResponse({
+          features: [photonFeature('05010-000', [-46.633308, -23.55052])],
+        })
       );
 
     const location = await fetchGeocoordinateFromBrazilLocation({
@@ -36,10 +37,11 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls[0][0]).toContain('street=Rua+Caiubi');
-    expect(fetchMock.mock.calls[0][0]).toContain('postalcode=05010000');
-    expect(fetchMock.mock.calls[1][0]).not.toContain('street=');
-    expect(fetchMock.mock.calls[1][0]).toContain('postalcode=05010000');
+    expect(fetchMock.mock.calls[0][0]).toContain('q=');
+    expect(fetchMock.mock.calls[0][0]).toContain('Rua+Caiubi');
+    expect(fetchMock.mock.calls[0][0]).toContain('05010000');
+    expect(fetchMock.mock.calls[1][0]).not.toContain('Rua+Caiubi');
+    expect(fetchMock.mock.calls[1][0]).toContain('05010000');
     expect(location).toEqual({
       type: 'Point',
       coordinates: {
@@ -50,7 +52,9 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
   });
 
   test('retorna coordenada indisponivel quando nenhuma tentativa encontra resultado', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue(createFetchResponse([]));
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      createFetchResponse({ features: [] })
+    );
 
     const location = await fetchGeocoordinateFromBrazilLocation({
       state: 'SP',

--- a/tests/solarIncidence.test.js
+++ b/tests/solarIncidence.test.js
@@ -6,7 +6,9 @@ vi.mock('axios');
 
 describe('solarIncidenceService', () => {
   test('should fetch solar incidence data', async () => {
-    const mockCoordinates = { lat: '-23.5505', lon: '-46.6333' }; // São Paulo
+    const mockGeocode = {
+      results: [{ latitude: -23.5475, longitude: -46.6361 }], // São Paulo
+    };
     const mockSolarData = {
       results: {
         sunrise: '2023-07-13T09:21:00+00:00',
@@ -17,7 +19,7 @@ describe('solarIncidenceService', () => {
     };
 
     axios.get
-      .mockResolvedValueOnce({ data: [mockCoordinates] })
+      .mockResolvedValueOnce({ data: mockGeocode })
       .mockResolvedValueOnce({ data: mockSolarData });
 
     const data = await getSolarIncidence('sao_paulo');
@@ -29,7 +31,7 @@ describe('solarIncidenceService', () => {
   });
 
   test('should throw when location is not found', async () => {
-    axios.get.mockResolvedValueOnce({ data: [] });
+    axios.get.mockResolvedValueOnce({ data: { results: [] } });
 
     await expect(getSolarIncidence('local_inexistente')).rejects.toThrow(
       'Localização não encontrada'


### PR DESCRIPTION
## Problema
A geolocalização do CEP v2 retornava `coordinates: {}` silenciosamente: o **Nominatim** (OpenStreetMap) rate-limita 1 req/s por IP e os IPs compartilhados da Vercel estouravam o limite (429) — mesmo padrão do endpoint solar (fix #846). Resolve as issues **#593, #596, #741, #784** (e parcialmente #649/#536).

## Mudanças
- Geocoder trocado para **Photon (komoot)** — mesma base OSM, sem rate-limit agressivo, sem key
- Fix: `require('https')` em arquivo ESM (quebrava no runtime do Next)
- Adaptação ao formato do Photon (`{features: [...]}` + `geometry.coordinates`)

## Validação
- Testado localmente: `/cep/v2/14096180` → 200 com `location.coordinates` reais (-47.7857, -21.2060) + IBGE correto