### PR TITLE
fix(cep): tolera respostas não-JSON do Photon (500 em produção)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -106,7 +106,13 @@ async function fetchGeocoordinateFromBrazilLocation({
     return unavailableCoordinate;
   }
 
-  let locations = (await response.json()).features;
+  let locations;
+  try {
+    locations = (await response.json()).features;
+  } catch {
+    return unavailableCoordinate;
+  }
+
   let location = findLocationByCep(locations, cep);
 
   if (!location && street && cleanedCep) {
@@ -121,7 +127,12 @@ async function fetchGeocoordinateFromBrazilLocation({
     });
 
     if (response?.ok) {
-      locations = (await response.json()).features;
+      try {
+        locations = (await response.json()).features;
+      } catch {
+        return unavailableCoordinate;
+      }
+
       location = findLocationByCep(locations, cep);
     }
   }


### PR DESCRIPTION
O `/cep/v2` voltou a dar 500 em produção após o merge do #848: o **Photon responde 200 com HTML/erro para os IPs da Vercel** e o `response.json()` lançava. Agora qualquer falha de parse retorna `coordinates` indisponíveis (200) em vez de 500. Teste no preview: verificar se a geolocalização funciona dos IPs da Vercel (se não, o fallback para Open-Meteo — acessível da Vercel, como o solar — será o próximo passo).