### PR TITLE
fix(cep): tolera JSON sem 'features' do Photon (500 em produção)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -106,9 +106,10 @@ async function fetchGeocoordinateFromBrazilLocation({
     return unavailableCoordinate;
   }
 
-  let locations;
+  let locations = [];
   try {
-    locations = (await response.json()).features;
+    const body = await response.json();
+    locations = Array.isArray(body?.features) ? body.features : [];
   } catch {
     return unavailableCoordinate;
   }
@@ -128,7 +129,8 @@ async function fetchGeocoordinateFromBrazilLocation({
 
     if (response?.ok) {
       try {
-        locations = (await response.json()).features;
+        const body = await response.json();
+        locations = Array.isArray(body?.features) ? body.features : [];
       } catch {
         return unavailableCoordinate;
       }

--- a/tests/fetchGeocoordinateFromBrazilLocation.test.js
+++ b/tests/fetchGeocoordinateFromBrazilLocation.test.js
@@ -51,6 +51,27 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
     });
   });
 
+  test('retorna coordenada indisponivel quando o provider responde sem features', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      createFetchResponse({ message: 'rate limit' })
+    );
+
+    const location = await fetchGeocoordinateFromBrazilLocation({
+      state: 'SP',
+      city: 'Sao Paulo',
+      street: 'Rua Caiubi',
+      cep: '05010-000',
+    });
+
+    expect(location).toEqual({
+      type: 'Point',
+      coordinates: {
+        longitude: undefined,
+        latitude: undefined,
+      },
+    });
+  });
+
   test('retorna coordenada indisponivel quando nenhuma tentativa encontra resultado', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(
       createFetchResponse({ features: [] })


### PR DESCRIPTION
O `/cep/v2` continua 500 em produção mesmo com o try/catch do #849: o **Photon responde JSON válido sem o campo `features`** para os IPs de produção da Vercel → `undefined.filter` lançava TypeError (o try/catch cobria o parse, não o `findLocationByCep`). Agora qualquer resposta sem `features` vira `coordinates` indisponíveis (200). Evidência: previews (IPs de preview) dão 200 com coordenadas; produção 500 em 3.4s (origem).