### PR TITLE
fix(cep): coordinates null em vez de undefined (500 em produção)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -52,7 +52,7 @@ function findLocationByCep(locations, cep) {
 function parseLocation(location) {
   const unavailableCoordinate = {
     type: 'Point',
-    coordinates: { longitude: undefined, latitude: undefined },
+    coordinates: { longitude: null, latitude: null },
   };
 
   if (!location) {
@@ -75,7 +75,7 @@ async function fetchGeocoordinateFromBrazilLocation({
 }) {
   const unavailableCoordinate = {
     type: 'Point',
-    coordinates: { longitude: undefined, latitude: undefined },
+    coordinates: { longitude: null, latitude: null },
   };
   const agent = getAgent();
   const headers = new Headers({

--- a/tests/fetchGeocoordinateFromBrazilLocation.test.js
+++ b/tests/fetchGeocoordinateFromBrazilLocation.test.js
@@ -66,8 +66,8 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
     expect(location).toEqual({
       type: 'Point',
       coordinates: {
-        longitude: undefined,
-        latitude: undefined,
+        longitude: null,
+        latitude: null,
       },
     });
   });
@@ -87,8 +87,8 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
     expect(location).toEqual({
       type: 'Point',
       coordinates: {
-        longitude: undefined,
-        latitude: undefined,
+        longitude: null,
+        latitude: null,
       },
     });
   });


### PR DESCRIPTION
O `/cep/v2` retorna 500 com body `{}` em produção quando o Photon não encontra coordenadas: o Next serializa `undefined` aninhado como erro. Troca para `null` — o contrato volta ao comportamento original (200 com `coordinates: {longitude: null, latitude: null}`). Corrige a regressão introduzida pela migração Nominatim→Photon (#848/#849/#851).