### PR TITLE
fix(cep): refatora geocoding (signal por fetch, street null-safe)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -12,7 +12,9 @@ function getAgent() {
 
 function extractAltFromStreet(street) {
   const regex = /-.*$/gm;
-  return street.replace(regex, '').trim();
+  return String(street ?? '')
+    .replace(regex, '')
+    .trim();
 }
 
 function getRandomUserAgent() {
@@ -61,10 +63,50 @@ function parseLocation(location) {
 
   const [longitude, latitude] = location.geometry?.coordinates ?? [];
 
+  if (longitude == null || latitude == null) {
+    return unavailableCoordinate;
+  }
+
   return {
     type: 'Point',
     coordinates: { longitude: String(longitude), latitude: String(latitude) },
   };
+}
+
+const PHOTON_API_URL = 'https://photon.komoot.io/api/';
+const PHOTON_TIMEOUT_MS = 3000;
+
+async function fetchPhoton(query) {
+  const queryParams = new URLSearchParams({
+    q: query,
+    limit: '10',
+  });
+
+  const requestConfig = {
+    agent: getAgent(),
+    headers: new Headers({
+      'User-Agent': getRandomUserAgent(),
+    }),
+    signal: AbortSignal.timeout(PHOTON_TIMEOUT_MS),
+  };
+
+  const response = await fetch(
+    `${PHOTON_API_URL}?${queryParams.toString()}`,
+    requestConfig
+  ).catch(() => {
+    return { ok: false };
+  });
+
+  if (!response?.ok) {
+    return [];
+  }
+
+  try {
+    const body = await response.json();
+    return Array.isArray(body?.features) ? body.features : [];
+  } catch {
+    return [];
+  }
 }
 
 async function fetchGeocoordinateFromBrazilLocation({
@@ -77,66 +119,18 @@ async function fetchGeocoordinateFromBrazilLocation({
     type: 'Point',
     coordinates: { longitude: null, latitude: null },
   };
-  const agent = getAgent();
-  const headers = new Headers({
-    'User-Agent': getRandomUserAgent(),
-  });
-  const requestConfig = {
-    agent,
-    headers,
-    signal: AbortSignal.timeout(3000),
-  };
   const cleanedCep = cep ? onlyDigits(cep) : null;
   const query = [extractAltFromStreet(street), city, state, cleanedCep]
     .filter(Boolean)
     .join(', ');
-  const queryParams = new URLSearchParams({
-    q: query,
-    limit: '10',
-  });
 
-  let response = await fetch(
-    `https://photon.komoot.io/api/?${queryParams.toString()}`,
-    requestConfig
-  ).catch(() => {
-    return { ok: false };
-  });
-
-  if (!response?.ok) {
-    return unavailableCoordinate;
-  }
-
-  let locations = [];
-  try {
-    const body = await response.json();
-    locations = Array.isArray(body?.features) ? body.features : [];
-  } catch {
-    return unavailableCoordinate;
-  }
-
+  let locations = await fetchPhoton(query);
   let location = findLocationByCep(locations, cep);
 
   if (!location && street && cleanedCep) {
     const retryQuery = [city, state, cleanedCep].filter(Boolean).join(', ');
-    queryParams.set('q', retryQuery);
-
-    response = await fetch(
-      `https://photon.komoot.io/api/?${queryParams.toString()}`,
-      requestConfig
-    ).catch(() => {
-      return { ok: false };
-    });
-
-    if (response?.ok) {
-      try {
-        const body = await response.json();
-        locations = Array.isArray(body?.features) ? body.features : [];
-      } catch {
-        return unavailableCoordinate;
-      }
-
-      location = findLocationByCep(locations, cep);
-    }
+    locations = await fetchPhoton(retryQuery);
+    location = findLocationByCep(locations, cep);
   }
 
   if (!location) {


### PR DESCRIPTION
Corrige o 500 `{}` persistente do `/cep/v2` em produção:

1. **`extractAltFromStreet` null-safe** — provider sem logradouro (`street: undefined`) lançava TypeError → o catch da rota serializa erro nativo como `{}` (JSON.stringify de TypeError = `{}`) → 500 sem body
2. **Signal novo por fetch** — o retry reusava o `AbortSignal` já abortado do primeiro fetch (timeout de 3s) — comportamento do undici com signal abortado no runtime da Vercel
3. **parseLocation** — coords ausentes vira `null` (nunca a string `"undefined"`)

Validado localmente: unit 3/3, E2E cep-v2 13/13, endpoint 200 com coords+IBGE+timezone.