### PR TITLE
fix(cep): fallback Open-Meteo no geocoding + timeout 2s (latência de 8s)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -74,7 +74,32 @@ function parseLocation(location) {
 }
 
 const PHOTON_API_URL = 'https://photon.komoot.io/api/';
-const PHOTON_TIMEOUT_MS = 3000;
+const OPEN_METEO_API_URL = 'https://geocoding-api.open-meteo.com/v1/search';
+const GEOCODING_TIMEOUT_MS = 2000;
+
+async function fetchJson(url) {
+  const requestConfig = {
+    agent: getAgent(),
+    headers: new Headers({
+      'User-Agent': getRandomUserAgent(),
+    }),
+    signal: AbortSignal.timeout(GEOCODING_TIMEOUT_MS),
+  };
+
+  const response = await fetch(url, requestConfig).catch(() => {
+    return { ok: false };
+  });
+
+  if (!response?.ok) {
+    return null;
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
 
 async function fetchPhoton(query) {
   const queryParams = new URLSearchParams({
@@ -82,31 +107,31 @@ async function fetchPhoton(query) {
     limit: '10',
   });
 
-  const requestConfig = {
-    agent: getAgent(),
-    headers: new Headers({
-      'User-Agent': getRandomUserAgent(),
-    }),
-    signal: AbortSignal.timeout(PHOTON_TIMEOUT_MS),
-  };
+  const body = await fetchJson(`${PHOTON_API_URL}?${queryParams.toString()}`);
 
-  const response = await fetch(
-    `${PHOTON_API_URL}?${queryParams.toString()}`,
-    requestConfig
-  ).catch(() => {
-    return { ok: false };
+  return Array.isArray(body?.features) ? body.features : [];
+}
+
+async function fetchOpenMeteo(city, state) {
+  const queryParams = new URLSearchParams({
+    name: [city, state].filter(Boolean).join(', '),
+    count: '5',
+    language: 'pt',
+    format: 'json',
   });
 
-  if (!response?.ok) {
-    return [];
-  }
+  const body = await fetchJson(
+    `${OPEN_METEO_API_URL}?${queryParams.toString()}`
+  );
+  const results = Array.isArray(body?.results) ? body.results : [];
 
-  try {
-    const body = await response.json();
-    return Array.isArray(body?.features) ? body.features : [];
-  } catch {
-    return [];
-  }
+  return results
+    .filter((item) => item.latitude != null && item.longitude != null)
+    .map((item) => ({
+      geometry: {
+        coordinates: [item.longitude, item.latitude],
+      },
+    }));
 }
 
 async function fetchGeocoordinateFromBrazilLocation({
@@ -131,6 +156,11 @@ async function fetchGeocoordinateFromBrazilLocation({
     const retryQuery = [city, state, cleanedCep].filter(Boolean).join(', ');
     locations = await fetchPhoton(retryQuery);
     location = findLocationByCep(locations, cep);
+  }
+
+  if (!location) {
+    locations = await fetchOpenMeteo(city, state);
+    location = locations[0];
   }
 
   if (!location) {


### PR DESCRIPTION
O Photon não responde dos IPs de produção da Vercel (timeouts de 3s ×2 → **~8s de latência** no `/cep/v2`, geolocalização null). Causa provável do 504 relatado na #693.

Mudanças:
- Timeout de geocoding: 3s → **2s** por chamada
- **Fallback Open-Meteo** (mesmo provider do `/solar`, validado rápido da Vercel): quando Photon falha/sem resultado, busca as coordenadas da cidade via Open-Meteo

Pior caso: ~6s (raro) · comum: ~1s · geolocalização funcional mesmo com o Photon fora.
Validado: unit 3/3 + E2E cep-v2 13/13 + Open-Meteo 200 em 0.95s.