### PR TITLE
fix(cep): corrige lint do fallback Open-Meteo (deploy ERROR)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -160,7 +160,7 @@ async function fetchGeocoordinateFromBrazilLocation({
 
   if (!location) {
     locations = await fetchOpenMeteo(city, state);
-    location = locations[0];
+    [location] = locations;
   }
 
   if (!location) {


### PR DESCRIPTION
O build de produção do #854 falhou no ESLint (`prefer-destructuring` em `locations[0]`). Corrigido com destructuring. Lint validado localmente.