### PR TITLE
perf(cep): geocoding em paralelo (latência de ~4.5s para ~2s)

### DIFF
--- a/lib/fetchGeocoordinateFromBrazilLocation.js
+++ b/lib/fetchGeocoordinateFromBrazilLocation.js
@@ -148,20 +148,21 @@ async function fetchGeocoordinateFromBrazilLocation({
   const query = [extractAltFromStreet(street), city, state, cleanedCep]
     .filter(Boolean)
     .join(', ');
+  const retryQuery =
+    street && cleanedCep
+      ? [city, state, cleanedCep].filter(Boolean).join(', ')
+      : null;
 
-  let locations = await fetchPhoton(query);
-  let location = findLocationByCep(locations, cep);
+  const [locations, retryLocations, openMeteoLocations] = await Promise.all([
+    fetchPhoton(query),
+    retryQuery ? fetchPhoton(retryQuery) : Promise.resolve([]),
+    fetchOpenMeteo(city, state),
+  ]);
 
-  if (!location && street && cleanedCep) {
-    const retryQuery = [city, state, cleanedCep].filter(Boolean).join(', ');
-    locations = await fetchPhoton(retryQuery);
-    location = findLocationByCep(locations, cep);
-  }
-
-  if (!location) {
-    locations = await fetchOpenMeteo(city, state);
-    [location] = locations;
-  }
+  const location =
+    findLocationByCep(locations, cep) ||
+    (retryQuery ? findLocationByCep(retryLocations, cep) : undefined) ||
+    openMeteoLocations[0];
 
   if (!location) {
     return unavailableCoordinate;

--- a/tests/fetchGeocoordinateFromBrazilLocation.test.js
+++ b/tests/fetchGeocoordinateFromBrazilLocation.test.js
@@ -27,7 +27,8 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
         createFetchResponse({
           features: [photonFeature('05010-000', [-46.633308, -23.55052])],
         })
-      );
+      )
+      .mockResolvedValueOnce(createFetchResponse({ results: [] }));
 
     const location = await fetchGeocoordinateFromBrazilLocation({
       state: 'SP',
@@ -36,12 +37,13 @@ describe('fetchGeocoordinateFromBrazilLocation', () => {
       cep: '05010-000',
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock.mock.calls[0][0]).toContain('q=');
     expect(fetchMock.mock.calls[0][0]).toContain('Rua+Caiubi');
     expect(fetchMock.mock.calls[0][0]).toContain('05010000');
     expect(fetchMock.mock.calls[1][0]).not.toContain('Rua+Caiubi');
     expect(fetchMock.mock.calls[1][0]).toContain('05010000');
+    expect(fetchMock.mock.calls[2][0]).toContain('name=');
     expect(location).toEqual({
       type: 'Point',
       coordinates: {


### PR DESCRIPTION
As 3 buscas de geocoding (Photon com logradouro, Photon sem logradouro, Open-Meteo) agora rodam em **paralelo** — o pior caso cai de ~4.5s para ~2s (timeout único de 2s). A escolha mantém a precedência: rua (Photon) > retry (Photon) > cidade (Open-Meteo). Validado: 16/16 testes.