### PR TITLE
fix(pix): parser filtra pelo ISPB (coluna 2) e campos ausentes viram null

### DIFF
--- a/services/pix/participants.js
+++ b/services/pix/participants.js
@@ -71,14 +71,14 @@ export const formatCsvFile = (file) => {
   try {
     return lines
       .map((line) => line.split(';').map((field) => field.trim()))
-      .filter(([ispb]) => ispb)
+      .filter((data) => data[2])
       .map((data) => {
         return {
           ispb: data[2],
           nome: data[1],
           nome_reduzido: data[1],
-          modalidade_participacao: data[8],
-          tipo_participacao: data[6],
+          modalidade_participacao: data[8] || null,
+          tipo_participacao: data[6] || null,
           inicio_operacao: null,
         };
       })

--- a/tests/services/pix/participants.test.js
+++ b/tests/services/pix/participants.test.js
@@ -22,4 +22,44 @@ describe('formatCsvFile', () => {
       },
     ]);
   });
+
+  test('mantem participantes com CNPJ vazio (filtra pelo ISPB, nao pela coluna 0)', () => {
+    const csv = [
+      'Lista de participantes ativos do Pix',
+      'CNPJ ; Nome Reduzido ; ISPB ; Nome Extenso ; Inicio ; Fim ; Tipo de Participação no SPI ; Status ; Modalidade de Participação no Pix',
+      ' ; Banco Sem Cnpj ; 99999999 ; Banco Sem Cnpj S.A. ; 2020-01-01 ; ; Direta ; Ativo ; Participante ',
+      '',
+    ].join('\r\n');
+
+    expect(formatCsvFile(csv)).toEqual([
+      {
+        ispb: '99999999',
+        nome: 'Banco Sem Cnpj',
+        nome_reduzido: 'Banco Sem Cnpj',
+        modalidade_participacao: 'Participante',
+        tipo_participacao: 'Direta',
+        inicio_operacao: null,
+      },
+    ]);
+  });
+
+  test('linhas com menos colunas viram null (nao undefined) nos campos opcionais', () => {
+    const csv = [
+      'Lista de participantes ativos do Pix',
+      'CNPJ ; Nome Reduzido ; ISPB ; Nome Extenso ; Inicio ; Fim ; Tipo de Participação no SPI ; Status ; Modalidade de Participação no Pix',
+      '00000000000191 ; Banco Curto ; 12345678',
+      '',
+    ].join('\r\n');
+
+    expect(formatCsvFile(csv)).toEqual([
+      {
+        ispb: '12345678',
+        nome: 'Banco Curto',
+        nome_reduzido: 'Banco Curto',
+        modalidade_participacao: null,
+        tipo_participacao: null,
+        inicio_operacao: null,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Corrige a **#709**: o `formatCsvFile` filtava pela coluna 0 (CNPJ) como se fosse o ISPB — participantes com CNPJ vazio eram descartados — e linhas com menos colunas produziam `undefined` (campos omitidos no JSON).

Mudanças:
- `filter((data) => data[2])` — filtra pelo ISPB real (3ª coluna)
- `modalidade_participacao`/`tipo_participacao` → `null` quando ausentes (nunca `undefined`)

Testes: 8/8 (3 do parser — incluindo 2 novos de regressão).