### PR TITLE
test(ibge): health check nos endpoints reais (bloqueio seletivo)

### DIFF
--- a/tests/ibge-cnae-v1.test.js
+++ b/tests/ibge-cnae-v1.test.js
@@ -7,7 +7,7 @@ let shouldSkipTests = false;
 
 try {
   const response = await axios.get(
-    'https://servicodados.ibge.gov.br/api/v1/localidades/estados',
+    'https://servicodados.ibge.gov.br/api/v2/cnae/classes/95118',
     { timeout: 5000 }
   );
   if (response.status !== 200) {

--- a/tests/ibge-municipios-v1.test.js
+++ b/tests/ibge-municipios-v1.test.js
@@ -8,7 +8,7 @@ let shouldSkipTests = false;
 
 try {
   const response = await axios.get(
-    'https://servicodados.ibge.gov.br/api/v1/localidades/estados',
+    'https://servicodados.ibge.gov.br/api/v1/localidades/estados/SC/municipios',
     { timeout: 5000 }
   );
   if (response.status !== 200) {


### PR DESCRIPTION
O IBGE bloqueia seletivamente os runners do GH Actions: `/api/v1/localidades/estados` responde, mas `/api/v2/cnae` e `/api/v1/localidades/estados/{uf}/municipios` são rejeitados com 'Request Rejected' (firewall).

Health checks agora batem no **mesmo endpoint que os testes usam**:
- `ibge-cnae-v1`: `/api/v2/cnae/classes/95118`
- `ibge-municipios-v1`: `/api/v1/localidades/estados/SC/municipios`

Isso ativa o `describe.skipIf` quando o endpoint real está bloqueado, em vez de rodar os testes e estourar timeout/500.