### PR TITLE
feat: adicionar segundo dia do Carnaval (rebase #677)

### DIFF
--- a/services/holidays/index.js
+++ b/services/holidays/index.js
@@ -150,6 +150,7 @@ export function getEasterHolidays(year) {
     date: formatDate(movingDate),
     name: 'Carnaval',
     type: 'national',
+    weekday: getWeekdayName(formatDate(movingDate)),
   });
   movingDate.setDate(movingDate.getDate() + 1);
   const carnavalDate = formatDate(movingDate);

--- a/services/holidays/index.js
+++ b/services/holidays/index.js
@@ -145,7 +145,13 @@ export function getEasterHolidays(year) {
     type: 'national',
     weekday: getWeekdayName(goodFridayDate),
   });
-  movingDate.setDate(movingDate.getDate() - 45);
+  movingDate.setDate(movingDate.getDate() - 46);
+  holidays.push({
+    date: formatDate(movingDate),
+    name: 'Carnaval',
+    type: 'national',
+  });
+  movingDate.setDate(movingDate.getDate() + 1);
   const carnavalDate = formatDate(movingDate);
   holidays.push({
     date: carnavalDate,

--- a/tests/feriados-v1.test.js
+++ b/tests/feriados-v1.test.js
@@ -102,7 +102,7 @@ describe('/feriados/v1 (E2E)', () => {
 
     expect.assertions(2);
 
-    expect(data).toHaveLength(12);
+    expect(data).toHaveLength(13);
     expect(data).toEqual(
       expect.arrayContaining(getHolidays(2019, ['Páscoa', 'Tiradentes']))
     );
@@ -114,7 +114,7 @@ describe('/feriados/v1 (E2E)', () => {
     const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2023`;
     const { data } = await axios.get(requestUrl);
 
-    expect(data).toHaveLength(12);
+    expect(data).toHaveLength(13);
     expect(data).toEqual(
       expect.not.arrayContaining(
         getHolidays(2024, ['Dia da consciência negra'])
@@ -128,7 +128,7 @@ describe('/feriados/v1 (E2E)', () => {
     const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2024`;
     const { data } = await axios.get(requestUrl);
 
-    expect(data).toHaveLength(13);
+    expect(data).toHaveLength(14);
     expect(data).toEqual(
       expect.arrayContaining(getHolidays(2024, ['Dia da consciência negra']))
     );

--- a/tests/helpers/feriados/index.js
+++ b/tests/helpers/feriados/index.js
@@ -1,6 +1,6 @@
 const carnavalDaysByYear = {
-  2020: '2020-02-25',
-  2010: '2010-02-16',
+  2020: ['2020-02-24', '2020-02-25'],
+  2010: ['2010-02-15', '2010-02-16'],
 };
 
 const pascoaDaysByYear = {
@@ -52,33 +52,35 @@ const getWeekdayName = (dateString) => {
   return weekdays[date.getDay()];
 };
 
-const getEasterHolidays = (year, holidaysName = easterHolidaysName) =>
-  [
-    {
-      date: carnavalDaysByYear[year],
+const getEasterHolidays = (year, holidaysName = easterHolidaysName) => {
+  const carnavalDates = carnavalDaysByYear[year] || [];
+  const carnavalHolidays = carnavalDates
+    .map(date => ({
+      date,
       name: 'Carnaval',
       type: 'national',
-      weekday: getWeekdayName(carnavalDaysByYear[year]),
-    },
+    }))
+    .filter(({ name }) => holidaysName.includes(name));
+
+  return [
+    ...carnavalHolidays,
     {
       date: pascoaDaysByYear[year],
       name: 'Páscoa',
       type: 'national',
-      weekday: getWeekdayName(pascoaDaysByYear[year]),
     },
     {
       date: goodFridayDaysByYear[year],
       name: 'Sexta-feira Santa',
       type: 'national',
-      weekday: getWeekdayName(goodFridayDaysByYear[year]),
     },
     {
       date: corpusChristiDaysByYear[year],
       name: 'Corpus Christi',
       type: 'national',
-      weekday: getWeekdayName(corpusChristiDaysByYear[year]),
     },
   ].filter(({ name }) => holidaysName.includes(name));
+};
 
 const getFixedHolidays = (year, holidaysName = fixedHolidaysName) => {
   const holidays = [
@@ -86,49 +88,41 @@ const getFixedHolidays = (year, holidaysName = fixedHolidaysName) => {
       date: `${year}-01-01`,
       name: 'Confraternização mundial',
       type: 'national',
-      weekday: getWeekdayName(`${year}-01-01`),
     },
     {
       date: `${year}-04-21`,
       name: 'Tiradentes',
       type: 'national',
-      weekday: getWeekdayName(`${year}-04-21`),
     },
     {
       date: `${year}-05-01`,
       name: 'Dia do trabalho',
       type: 'national',
-      weekday: getWeekdayName(`${year}-05-01`),
     },
     {
       date: `${year}-09-07`,
       name: 'Independência do Brasil',
       type: 'national',
-      weekday: getWeekdayName(`${year}-09-07`),
     },
     {
       date: `${year}-10-12`,
       name: 'Nossa Senhora Aparecida',
       type: 'national',
-      weekday: getWeekdayName(`${year}-10-12`),
     },
     {
       date: `${year}-11-02`,
       name: 'Finados',
       type: 'national',
-      weekday: getWeekdayName(`${year}-11-02`),
     },
     {
       date: `${year}-11-15`,
       name: 'Proclamação da República',
       type: 'national',
-      weekday: getWeekdayName(`${year}-11-15`),
     },
     {
       date: `${year}-12-25`,
       name: 'Natal',
       type: 'national',
-      weekday: getWeekdayName(`${year}-12-25`),
     },
   ];
 
@@ -137,7 +131,6 @@ const getFixedHolidays = (year, holidaysName = fixedHolidaysName) => {
       date: `${year}-11-20`,
       name: 'Dia da consciência negra',
       type: 'national',
-      weekday: getWeekdayName(`${year}-11-20`),
     });
   }
 

--- a/tests/helpers/feriados/index.js
+++ b/tests/helpers/feriados/index.js
@@ -52,35 +52,33 @@ const getWeekdayName = (dateString) => {
   return weekdays[date.getDay()];
 };
 
-const getEasterHolidays = (year, holidaysName = easterHolidaysName) => {
-  const carnavalDates = carnavalDaysByYear[year] || [];
-  const carnavalHolidays = carnavalDates
-    .map(date => ({
+const getEasterHolidays = (year, holidaysName = easterHolidaysName) =>
+  [
+    ...(carnavalDaysByYear[year] || []).map((date) => ({
       date,
       name: 'Carnaval',
       type: 'national',
-    }))
-    .filter(({ name }) => holidaysName.includes(name));
-
-  return [
-    ...carnavalHolidays,
+      weekday: getWeekdayName(date),
+    })),
     {
       date: pascoaDaysByYear[year],
       name: 'Páscoa',
       type: 'national',
+      weekday: getWeekdayName(pascoaDaysByYear[year]),
     },
     {
       date: goodFridayDaysByYear[year],
       name: 'Sexta-feira Santa',
       type: 'national',
+      weekday: getWeekdayName(goodFridayDaysByYear[year]),
     },
     {
       date: corpusChristiDaysByYear[year],
       name: 'Corpus Christi',
       type: 'national',
+      weekday: getWeekdayName(corpusChristiDaysByYear[year]),
     },
   ].filter(({ name }) => holidaysName.includes(name));
-};
 
 const getFixedHolidays = (year, holidaysName = fixedHolidaysName) => {
   const holidays = [
@@ -88,41 +86,49 @@ const getFixedHolidays = (year, holidaysName = fixedHolidaysName) => {
       date: `${year}-01-01`,
       name: 'Confraternização mundial',
       type: 'national',
+      weekday: getWeekdayName(`${year}-01-01`),
     },
     {
       date: `${year}-04-21`,
       name: 'Tiradentes',
       type: 'national',
+      weekday: getWeekdayName(`${year}-04-21`),
     },
     {
       date: `${year}-05-01`,
       name: 'Dia do trabalho',
       type: 'national',
+      weekday: getWeekdayName(`${year}-05-01`),
     },
     {
       date: `${year}-09-07`,
       name: 'Independência do Brasil',
       type: 'national',
+      weekday: getWeekdayName(`${year}-09-07`),
     },
     {
       date: `${year}-10-12`,
       name: 'Nossa Senhora Aparecida',
       type: 'national',
+      weekday: getWeekdayName(`${year}-10-12`),
     },
     {
       date: `${year}-11-02`,
       name: 'Finados',
       type: 'national',
+      weekday: getWeekdayName(`${year}-11-02`),
     },
     {
       date: `${year}-11-15`,
       name: 'Proclamação da República',
       type: 'national',
+      weekday: getWeekdayName(`${year}-11-15`),
     },
     {
       date: `${year}-12-25`,
       name: 'Natal',
       type: 'national',
+      weekday: getWeekdayName(`${year}-12-25`),
     },
   ];
 
@@ -131,6 +137,7 @@ const getFixedHolidays = (year, holidaysName = fixedHolidaysName) => {
       date: `${year}-11-20`,
       name: 'Dia da consciência negra',
       type: 'national',
+      weekday: getWeekdayName(`${year}-11-20`),
     });
   }
 


### PR DESCRIPTION
Rebase do PR original (#677, fork MatheusPrudente) na main atual.

Adiciona a **segunda-feira de Carnaval** como feriado nacional (a main já tinha a terça). Conflito resolvido no cálculo: agora os dois dias são retornados (segunda + terça).

Também ajusta o helper de testes para suportar múltiplos dias de carnaval (array) e a contagem de feriados (12 → 13).