### PR TITLE
fix: não serializar erros crus nas rotas (vazava stack/config)

### DIFF
--- a/pages/api/cep/v2/[cep].js
+++ b/pages/api/cep/v2/[cep].js
@@ -45,14 +45,23 @@ async function getCepWithLocation(request, response) {
           break;
       }
 
-      response.json(error);
+      response.json({
+        name: error.name,
+        message: error.message,
+        type: error.type,
+        errors: error.errors || [],
+      });
       return;
     } else if (error.type === 'bad_request') {
       throw error;
     }
 
     response.status(500);
-    response.json(error);
+    response.json({
+      message: error.message || 'Erro interno do servidor',
+      type: 'internal_error',
+      name: error.name || 'InternalServerError',
+    });
   }
 }
 

--- a/pages/api/cep/v3/[cep].js
+++ b/pages/api/cep/v3/[cep].js
@@ -112,11 +112,20 @@ async function Cep(request, response) {
           break;
       }
 
-      return response.json(error);
+      return response.json({
+        name: error.name,
+        message: error.message,
+        type: error.type,
+        errors: error.errors || [],
+      });
     }
 
     response.status(500);
-    return response.json(error);
+    return response.json({
+      message: error.message || 'Erro interno do servidor',
+      type: 'internal_error',
+      name: error.name || 'InternalServerError',
+    });
   }
 }
 

--- a/pages/api/universities/v1/[id].js
+++ b/pages/api/universities/v1/[id].js
@@ -24,7 +24,11 @@ async function UniversityById(request, response) {
   } catch (error) {
     response.status(500);
 
-    response.json(error);
+    response.json({
+      message: error.message || 'Erro interno do servidor',
+      type: 'internal_error',
+      name: error.name || 'InternalServerError',
+    });
   }
 }
 

--- a/pages/api/universities/v1/index.js
+++ b/pages/api/universities/v1/index.js
@@ -17,7 +17,11 @@ async function Universities(request, response) {
   } catch (error) {
     response.status(500);
 
-    response.json(error);
+    response.json({
+      message: error.message || 'Erro interno do servidor',
+      type: 'internal_error',
+      name: error.name || 'InternalServerError',
+    });
   }
 }
 


### PR DESCRIPTION
## Problema
As rotas `universities` (v1 index e [id]) e o catch 500 genérico do CEP v2/v3 serializavam o erro cru com `response.json(error)` — o AxiosError serializa `stack` e `config` (URLs, headers) em respostas públicas 500.

## Mudanças
- `universities/v1/index.js` e `[id].js`: catch 500 responde `{message, type, name}` (shape seguro)
- `cep/v2/[cep].js` e `cep/v3/[cep].js`: CepPromiseError mantém o contrato público (name/message/type/errors, serializado explicitamente); catch 500 genérico usa shape seguro

## Verificação
- Lint: 0 erros
- Build local: passa
- Testes CEP v2/v3: contrato preservado (service_error usa toMatchObject, validation_error usa toEqual)