### PR TITLE
fix: eleições retornam 400 JSON para parâmetros inválidos

### DIFF
--- a/pages/api/eleicoes/candidaturas/[candidato].js
+++ b/pages/api/eleicoes/candidaturas/[candidato].js
@@ -1,4 +1,5 @@
 import { searchCandidate } from '@/services/eleicoes';
+import BadRequestError from '@/errors/BadRequestError';
 
 export default async function SearchCandidate(request, response) {
   const { election, year, municipality, candidato } = request.query;
@@ -13,6 +14,14 @@ export default async function SearchCandidate(request, response) {
 
     return response.status(200).json(candidatoData);
   } catch (error) {
+    if (error instanceof BadRequestError) {
+      return response.status(400).json({
+        message: error.message,
+        type: error.type,
+        name: error.name,
+      });
+    }
+
     if (error.name === 'CandidateNotFoundError') {
       return response.status(404).json({
         message: 'Candidato não encontrado.',

--- a/pages/api/eleicoes/candidaturas/index.js
+++ b/pages/api/eleicoes/candidaturas/index.js
@@ -1,4 +1,5 @@
 import { listCandidatureByMunicipality } from '@/services/eleicoes/candidaturas';
+import BadRequestError from '@/errors/BadRequestError';
 
 export default async function Candidature(request, response) {
   const { election, year, municipality, position } = request.query;
@@ -13,6 +14,14 @@ export default async function Candidature(request, response) {
 
     return response.status(200).json(candidaturas);
   } catch (error) {
+    if (error instanceof BadRequestError) {
+      return response.status(400).json({
+        message: error.message,
+        type: error.type,
+        name: error.name,
+      });
+    }
+
     if (error.name === 'CandidaturesPromiseError') {
       return response.status(500).json({
         message: 'Erro ao buscar candidaturas.',

--- a/pages/api/eleicoes/cargos-por-municipio.js
+++ b/pages/api/eleicoes/cargos-por-municipio.js
@@ -1,4 +1,5 @@
 import { listPositionsByMunicipality } from '@/services/eleicoes/cargos-por-municipio';
+import BadRequestError from '@/errors/BadRequestError';
 
 export default async function PositionsByMunicipality(request, response) {
   const { election, municipality } = request.query;
@@ -7,6 +8,14 @@ export default async function PositionsByMunicipality(request, response) {
 
     return response.status(200).json(positions);
   } catch (error) {
+    if (error instanceof BadRequestError) {
+      return response.status(400).json({
+        message: error.message,
+        type: error.type,
+        name: error.name,
+      });
+    }
+
     if (error.name === 'PositionsByMunicipalityPromiseError')
       return response.status(500).json({
         message: 'Erro ao buscar cargos por município.',

--- a/services/eleicoes/candidaturas.js
+++ b/services/eleicoes/candidaturas.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import BadRequestError from '@/errors/BadRequestError';
 import {
   ELECTIONS_API_URL,
   CANDIDATE_LIST_URL,
@@ -14,24 +15,39 @@ export const listCandidatureByMunicipality = async (
   position
 ) => {
   if (!election || !year || !municipality || !position) {
-    throw new Error(ERRORMESSAGES.INVALID_PARAMETERS);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+    });
   }
 
   const yearStr = String(year);
   if (yearStr.length !== 4) {
-    throw new Error(ERRORMESSAGES.INVALID_YEAR);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_YEAR,
+      type: 'invalid_year',
+    });
   }
 
   if (typeof municipality !== 'string' && verifyIsNotNumber(municipality)) {
-    throw new Error(ERRORMESSAGES.INVALID_MUNICIPALITY);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_MUNICIPALITY,
+      type: 'invalid_municipality',
+    });
   }
 
   if (typeof position !== 'string' && verifyIsNotNumber(position)) {
-    throw new Error(ERRORMESSAGES.INVALID_POSITION);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_POSITION,
+      type: 'invalid_position',
+    });
   }
 
   if (typeof election !== 'string' && verifyIsNotNumber(election)) {
-    throw new Error(ERRORMESSAGES.INVALID_ELECTION);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_ELECTION,
+      type: 'invalid_election',
+    });
   }
 
   try {
@@ -54,16 +70,29 @@ export const searchCandidate = async (
   candidate
 ) => {
   if (!election || !year || !municipality || !candidate)
-    throw new Error(ERRORMESSAGES.INVALID_PARAMETERS);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+    });
 
   const yearStr = String(year);
-  if (yearStr.length !== 4) throw new Error(ERRORMESSAGES.INVALID_YEAR);
+  if (yearStr.length !== 4)
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_YEAR,
+      type: 'invalid_year',
+    });
 
   if (typeof municipality !== 'string' && verifyIsNotNumber(municipality))
-    throw new Error(ERRORMESSAGES.INVALID_MUNICIPALITY);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_MUNICIPALITY,
+      type: 'invalid_municipality',
+    });
 
   if (typeof candidate !== 'string' && verifyIsNotNumber(candidate))
-    throw new Error(ERRORMESSAGES.INVALID_CANDIDATE);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_CANDIDATE,
+      type: 'invalid_candidate',
+    });
 
   try {
     const requestUrl = `${ELECTIONS_API_URL}${CANDIDATE_SEARCH_URL}/${yearStr}/${municipality}/${election}/candidato/${candidate}`;

--- a/services/eleicoes/cargos-por-municipio.js
+++ b/services/eleicoes/cargos-por-municipio.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import BadRequestError from '@/errors/BadRequestError';
 import {
   ELECTIONS_API_URL,
   ERRORMESSAGES,
@@ -8,13 +9,22 @@ import {
 
 export const listPositionsByMunicipality = async (election, municipality) => {
   if (!election || !municipality)
-    throw new Error(ERRORMESSAGES.INVALID_PARAMETERS);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+    });
 
   if (typeof municipality !== 'string' && verifyIsNotNumber(municipality))
-    throw new Error(ERRORMESSAGES.INVALID_MUNICIPALITY);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_MUNICIPALITY,
+      type: 'invalid_municipality',
+    });
 
   if (typeof election !== 'string' && verifyIsNotNumber(election))
-    throw new Error(ERRORMESSAGES.INVALID_ELECTION);
+    throw new BadRequestError({
+      message: ERRORMESSAGES.INVALID_ELECTION,
+      type: 'invalid_election',
+    });
 
   const requestUrl = `${ELECTIONS_API_URL}${POSITION_LIST_URL}/${election}/${municipality}/cargos`;
 

--- a/tests/eleicoes/candidatos/candidaturas-api.test.js
+++ b/tests/eleicoes/candidatos/candidaturas-api.test.js
@@ -71,9 +71,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(Candidature(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await Candidature(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando ano está ausente em Candidaturas', async () => {
@@ -94,9 +99,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(Candidature(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await Candidature(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando município está ausente em Candidaturas', async () => {
@@ -117,9 +127,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(Candidature(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await Candidature(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando posição está ausente em Candidaturas', async () => {
@@ -139,9 +154,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(Candidature(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await Candidature(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando ano tem formato inválido em Candidaturas', async () => {
@@ -162,9 +182,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(Candidature(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_YEAR
-    );
+    await Candidature(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_YEAR,
+      type: 'invalid_year',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando município tem tipo inválido em Candidaturas', async () => {
@@ -184,9 +209,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(Candidature(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_MUNICIPALITY
-    );
+    await Candidature(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_MUNICIPALITY,
+      type: 'invalid_municipality',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando posição tem tipo inválido em Candidaturas', async () => {
@@ -206,9 +236,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(Candidature(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_POSITION
-    );
+    await Candidature(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_POSITION,
+      type: 'invalid_position',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve responder 200 com os dados do candidato buscado (invocação in-process)', async () => {
@@ -299,9 +334,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(SearchCandidate(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await SearchCandidate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando ano está ausente em BuscarCandidato', async () => {
@@ -322,9 +362,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(SearchCandidate(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await SearchCandidate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando município está ausente em BuscarCandidato', async () => {
@@ -345,9 +390,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(SearchCandidate(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await SearchCandidate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando candidato está ausente em BuscarCandidato', async () => {
@@ -368,9 +418,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(SearchCandidate(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_PARAMETERS
-    );
+    await SearchCandidate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_PARAMETERS,
+      type: 'invalid_parameters',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando ano tem formato inválido em BuscarCandidato', async () => {
@@ -391,9 +446,14 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(SearchCandidate(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_YEAR
-    );
+    await SearchCandidate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_YEAR,
+      type: 'invalid_year',
+      name: 'BadRequestError',
+    });
   });
 
   it('deve lançar erro quando ano tem menos de 4 dígitos em BuscarCandidato', async () => {
@@ -414,8 +474,13 @@ describe('API handler /api/eleicoes/candidaturas/v1 - in-process', () => {
       send: vi.fn().mockReturnThis(),
     };
 
-    await expect(SearchCandidate(req, res)).rejects.toThrow(
-      ERRORMESSAGES.INVALID_YEAR
-    );
+    await SearchCandidate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: ERRORMESSAGES.INVALID_YEAR,
+      type: 'invalid_year',
+      name: 'BadRequestError',
+    });
   });
 });


### PR DESCRIPTION
## Problema
Parâmetros ausentes/inválidos nas APIs de eleições lançavam `Error` puro nos services → o handler rejeitava → Next renderizava **HTML 500** (sem JSON estruturado).

## Mudanças
- Services (`candidaturas.js`, `cargos-por-municipio.js`): lançam `BadRequestError` com type específico (invalid_parameters, invalid_year, invalid_municipality, invalid_position, invalid_election, invalid_candidate)
- Handlers (`candidaturas`, `[candidato]`, `cargos-por-municipio`): capturam `instanceof BadRequestError` → **400 JSON** `{message, type, name}`
- Testes de handler atualizados: `rejects.toThrow` → expect 400 + json

## Verificação
- 41/41 testes de eleições passando
- Lint: 0 erros