### PR TITLE
fix: não setar Cache-Control em respostas de erro (universities)

### DIFF
--- a/pages/api/universities/v1/[id].js
+++ b/pages/api/universities/v1/[id].js
@@ -8,8 +8,6 @@ const cors = microCors();
 async function UniversityById(request, response) {
   const { id } = request.query;
 
-  response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
-
   try {
     const university = await getUniversitiesById(id);
 
@@ -20,6 +18,7 @@ async function UniversityById(request, response) {
       });
     }
 
+    response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
     return response.status(200).json(university);
   } catch (error) {
     response.status(500);

--- a/pages/api/universities/v1/index.js
+++ b/pages/api/universities/v1/index.js
@@ -6,11 +6,10 @@ const CACHE_CONTROL_HEADER_VALUE =
 const cors = microCors();
 
 async function Universities(request, response) {
-  response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
-
   try {
     const universities = await getUniversities();
 
+    response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
     response.status(200);
 
     response.json(universities);


### PR DESCRIPTION
## Problema
`Cache-Control: max-age=0, s-maxage=86400` era setado ANTES do try/catch nas rotas de universities — respostas 500 saíam com s-maxage, o que poderia levar proxies/CDNs a cachear erros por 24h (issue #594).

## Observação
Testado em produção: o Vercel **não cacheia 5xx** (`x-vercel-cache: MISS` + `age: 0` em todas as tentativas), então não é bug ativo no Vercel — mas é boa prática e protege contra outros CDNs/proxies.

## Mudanças
- `universities/v1/index.js`: `setHeader` movido para o caminho de sucesso
- `universities/v1/[id].js`: idem

## Verificação
- Lint: 0 erros
- Testes: universities é E2E com skip condicional (provider fora)