### PR TITLE
fix: ibge/uf populacao_estimada quebrada (regressão do #877)

### DIFF
--- a/services/ibge/gov.js
+++ b/services/ibge/gov.js
@@ -75,10 +75,12 @@ export const getUfEstimatePopulationByCode = async (uf) => {
     `${URL_AGGREGATES}/${ESTIMATED_POPULATION_AGGREGATE_ID}/periodos/${LATEST_PERIOD}/variaveis?localidades=N3[${ufCode}]`
   );
 
-  data = data.find((item) => item.id === ESTIMATED_POPULATION_VARIABLE_ID);
+  data = data.find(
+    (item) => Number(item.id) === ESTIMATED_POPULATION_VARIABLE_ID
+  );
 
   if (!data) {
-    throw new InternalError('Empty data');
+    throw new InternalError({ message: 'Empty data' });
   }
 
   const result = data.resultados[0].series[0].serie;

--- a/tests/ibge-populacao-fix.test.js
+++ b/tests/ibge-populacao-fix.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getUfEstimatePopulationByCode } from '@/services/ibge/gov';
+
+describe('getUfEstimatePopulationByCode (fix #877 === bug)', () => {
+  it('encontra a variável com id string vindo do IBGE', async () => {
+    const result = await getUfEstimatePopulationByCode('35');
+    expect(result).toHaveProperty('populacao_estimada');
+    expect(typeof result.populacao_estimada).toBe('number');
+    expect(result).toHaveProperty('periodo');
+  });
+
+  it('aceita sigla (SP)', async () => {
+    const result = await getUfEstimatePopulationByCode('SP');
+    expect(typeof result.populacao_estimada).toBe('number');
+  });
+});


### PR DESCRIPTION
## 🔴 Regressão do #877 (meu fix de lint)

O lint fix do #877 trocou `==` por `===` na comparação de `item.id` com `ESTIMATED_POPULATION_VARIABLE_ID` (9324). O IBGE retorna o id como **string** (`"9324"`) no JSON do agregado → `'9324' === 9324` é `false` → `data.find` retorna undefined → `InternalError('Empty data')` → **500 em /api/ibge/uf/v1/[code]** (produção + CI).

## Fix
- `Number(item.id) === ESTIMATED_POPULATION_VARIABLE_ID` (compara como número)
- `new InternalError({ message: 'Empty data' })` — o construtor espera objeto (antes recebia string → `message` vazio no JSON de erro)

## Verificação
- Teste novo: `getUfEstimatePopulationByCode('35')` e `('SP')` retornam `populacao_estimada` numérico ✓ (2/2)
- Lint: 0 erros
- **Este bug explica o CI vermelho em ibge-uf nos PRs #878/#879/#880** (não era ambiental)