### PR TITLE
fix: feriados estaduais na rota + docs quebradas (schemas ausentes)

### DIFF
--- a/pages/api/feriados/v1/[ano].js
+++ b/pages/api/feriados/v1/[ano].js
@@ -1,16 +1,25 @@
 import app from '@/app';
 import BaseError from '@/errors/BaseError';
 import InternalError from '@/errors/InternalError';
+import BadRequestError from '@/errors/BadRequestError';
 import getHolidays from '@/services/holidays';
 
 async function getHolidaysByYear(request, response) {
   try {
-    const holidays = getHolidays(request.query.ano);
+    const { ano, uf } = request.query;
+    const holidays = getHolidays(ano, uf);
 
     return response.status(200).json(holidays);
   } catch (error) {
     if (error instanceof BaseError) {
       throw error;
+    }
+
+    if (error.message === 'Estado inválido') {
+      throw new BadRequestError({
+        message: 'UF inválida. Informe uma sigla válida (ex: SP, RJ, MG).',
+        type: 'invalid_uf',
+      });
     }
 
     throw new InternalError({

--- a/pages/docs/doc/cep.json
+++ b/pages/docs/doc/cep.json
@@ -1,444 +1,493 @@
 {
-    "tags": [
-        {
-            "name": "CEP",
-            "description": "Informações referentes a CEPs"
-        },
-        {
-            "name": "CEP V2",
-            "description": "A geolocalização dos CEPs estão <b>suscetíveis a erros</b>, pois as coordenadas são provindas do OpenStreetMap. Quando disponível, o CEP também é utilizado para refinar a busca e reduzir ambiguidades. Caso encontre algum erro você poderá corrigir no próprio OpenStreetMap que será refletido no CEP V2."
-        }
-    ],
-    "paths": {
-        "/cep/v1/{cep}": {
-            "get": {
-                "tags": [
-                    "CEP"
-                ],
-                "summary": "Busca por CEP com múltiplos providers de fallback.",
-                "description": "A busca utiliza como fonte principal o OpenCep, caso não encontre o CEP é buscado em diversos outros providers de CEP.",
-                "parameters": [
-                    {
-                        "name": "cep",
-                        "description": "O CEP (Código de Endereçamento Postal) é um sistema de códigos que visa racionalizar o processo de encaminhamento e entrega de correspondências através da divisão do país em regiões postais. ... Atualmente, o CEP é composto por oito dígitos, cinco de um lado e três de outro. Cada algarismo do CEP possui um significado.\n",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Address"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Todos os serviços de CEP retornaram erro.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CepError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cep/v2/{cep}": {
-            "get": {
-                "tags": [
-                    "CEP V2"
-                ],
-                "summary": "Busca por CEP com múltiplos providers e geolocalização.",
-                "description": "Versão 2 do serviço de busca por CEP que inclui informações de geolocalização (latitude e longitude) além dos dados básicos de endereço. Utiliza múltiplos provedores com sistema de fallback para garantir maior disponibilidade.",
-                "parameters": [
-                    {
-                        "name": "cep",
-                        "description": "CEP a ser consultado. Deve conter exatamente 8 dígitos, com ou sem formatação (hífen). Exemplo: 01310-930 ou 01310930.",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^[0-9]{8}$|^[0-9]{5}-[0-9]{3}$",
-                            "example": "01310930"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AddressV2"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "CEP inválido ou mal formatado.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "BadRequestError",
-                                    "message": "CEP deve conter exatamente 8 dígitos",
-                                    "type": "validation_error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "CEP não encontrado em nenhum provedor.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "NotFoundError",
-                                    "message": "CEP NAO ENCONTRADO",
-                                    "type": "service_error"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Erro interno no serviço de CEP.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "InternalError",
-                                    "message": "Erro interno no serviço de CEP",
-                                    "type": "internal_error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cep/v3/{cep}": {
-            "get": {
-                "tags": [
-                    "CEP V3"
-                ],
-                "summary": "Versão 3 do serviço de busca por CEP com múltiplos providers de fallback, com autocomplete de faixas de CEP.",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "cep",
-                        "description": "O CEP (Código de Endereçamento Postal) é um sistema de códigos que visa racionalizar o processo de encaminhamento e entrega de correspondências através da divisão do país em regiões postais. ... Atualmente, o CEP é composto por oito dígitos, cinco de um lado e três de outro. Cada algarismo do CEP possui um significado.\n",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AddressV3"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Todos os serviços de CEP retornaram erro.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/CepError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+  "tags": [
+    {
+      "name": "CEP",
+      "description": "Informações referentes a CEPs"
     },
-    "components": {
-        "schemas": {
-            "Coordinates": {
-                "title": "Coordinates",
-                "required": [
-                    "longitude",
-                    "latitude"
-                ],
-                "type": "object",
-                "properties": {
-                    "longitude": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "latitude": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "example": {
-                    "longitude": "-49.0629788",
-                    "latitude": "-26.9244749"
-                }
-            },
-            "Location": {
-                "title": "Location",
-                "required": [
-                    "type",
-                    "coordinates"
-                ],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "Point"
-                        ]
-                    },
-                    "coordinates": {
-                        "type": "object",
-                        "$ref": "#/components/schemas/Coordinates"
-                    }
-                },
-                "example": {
-                    "type": "Point",
-                    "coordinates": {
-                        "longitude": "-49.0629788",
-                        "latitude": "-26.9244749"
-                    }
-                }
-            },
-            "AddressV2": {
-                "title": "Address V2 with Geolocation",
-                "description": "Endereço completo com informações de geolocalização incluídas",
-                "required": [
-                    "cep",
-                    "state",
-                    "city",
-                    "neighborhood",
-                    "street",
-                    "timezoneName",
-                    "location"
-                ],
-                "type": "object",
-                "properties": {
-                    "cep": {
-                        "type": "string",
-                        "description": "Código de Endereçamento Postal"
-                    },
-                    "state": {
-                        "type": "string",
-                        "description": "Sigla do estado (UF)"
-                    },
-                    "city": {
-                        "type": "string",
-                        "description": "Nome da cidade"
-                    },
-                    "neighborhood": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Nome do bairro (pode ser nulo)"
-                    },
-                    "street": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Nome da rua/logradouro (pode ser nulo)"
-                    },
-                    "timezoneName": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Nome da timezone do local (pode ser nulo)"
-                    },
-                    "location": {
-                        "type": "object",
-                        "$ref": "#/components/schemas/Location",
-                        "description": "Coordenadas geográficas do endereço"
-                    },
-                    "ibge": {
-                        "type": "object",
-                        "$ref": "#/components/schemas/IbgeCodes",
-                        "description": "Códigos IBGE do município e do estado (podem ser nulos quando o provider não disponibiliza)"
-                    }
-                },
-                "example": {
-                    "cep": "89010025",
-                    "state": "SC",
-                    "city": "Blumenau",
-                    "neighborhood": "Centro",
-                    "street": "Rua Doutor Luiz de Freitas Melro",
-                    "timezoneName": "America/Sao_Paulo",
-                    "location": {
-                        "type": "Point",
-                        "coordinates": {
-                            "longitude": "-49.0629788",
-                            "latitude": "-26.9244749"
-                        }
-                    },
-                    "ibge": {
-                        "city": "4202404",
-                        "state": "42"
-                    }
-                }
-            },
-            "Address": {
-                "title": "Address",
-                "required": [
-                    "cep",
-                    "state",
-                    "city",
-                    "neighborhood",
-                    "street",
-                    "service"
-                ],
-                "type": "object",
-                "properties": {
-                    "cep": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "city": {
-                        "type": "string"
-                    },
-                    "neighborhood": {
-                        "type": "string"
-                    },
-                    "street": {
-                        "type": "string"
-                    },
-                    "service": {
-                        "type": "string"
-                    },
-                    "ibge": {
-                        "type": "object",
-                        "$ref": "#/components/schemas/IbgeCodes",
-                        "description": "Códigos IBGE do município e do estado (podem ser nulos quando o provider não disponibiliza)"
-                    }
-                },
-                "example": {
-                    "cep": "89010025",
-                    "state": "SC",
-                    "city": "Blumenau",
-                    "neighborhood": "Centro",
-                    "street": "Rua Doutor Luiz de Freitas Melro",
-                    "service": "viacep",
-                    "ibge": {
-                        "city": "4202404",
-                        "state": "42"
-                    }
-                }
-            },
-            "IbgeCodes": {
-                "title": "IBGE Codes",
-                "description": "Códigos IBGE associados ao endereço",
-                "type": "object",
-                "properties": {
-                    "city": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Código IBGE do município (7 dígitos), pode ser nulo se o provider não disponibiliza"
-                    },
-                    "state": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Código IBGE do estado (2 dígitos), pode ser nulo se a UF não puder ser identificada"
-                    }
-                },
-                "example": {
-                    "city": "4202404",
-                    "state": "42"
-                }
-            },
-            "CepError": {
-                "title": "CepError.",
-                "required": [
-                    "name",
-                    "message",
-                    "type",
-                    "errors"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "errors": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Error"
-                        },
-                        "description": ""
-                    }
-                },
-                "example": {
-                    "name": "CepPromiseError",
-                    "message": "Todos os serviços de CEP retornaram erro.",
-                    "type": "service_error",
-                    "errors": [
-                        {
-                            "name": "ServiceError",
-                            "message": "CEP INVÁLIDO",
-                            "service": "correios"
-                        },
-                        {
-                            "name": "ServiceError",
-                            "message": "CEP não encontrado na base do ViaCEP.",
-                            "service": "viacep"
-                        }
-                    ]
-                }
-            },
-            "Error": {
-                "title": "Error",
-                "required": [
-                    "name",
-                    "message",
-                    "service"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "service": {
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "name": "ServiceError",
-                    "message": "CEP INVÁLIDO",
-                    "service": "correios"
-                }
-            }
-        }
+    {
+      "name": "CEP V2",
+      "description": "A geolocalização dos CEPs estão <b>suscetíveis a erros</b>, pois as coordenadas são provindas do OpenStreetMap. Quando disponível, o CEP também é utilizado para refinar a busca e reduzir ambiguidades. Caso encontre algum erro você poderá corrigir no próprio OpenStreetMap que será refletido no CEP V2."
     }
+  ],
+  "paths": {
+    "/cep/v1/{cep}": {
+      "get": {
+        "tags": ["CEP"],
+        "summary": "Busca por CEP com múltiplos providers de fallback.",
+        "description": "A busca utiliza como fonte principal o OpenCep, caso não encontre o CEP é buscado em diversos outros providers de CEP.",
+        "parameters": [
+          {
+            "name": "cep",
+            "description": "O CEP (Código de Endereçamento Postal) é um sistema de códigos que visa racionalizar o processo de encaminhamento e entrega de correspondências através da divisão do país em regiões postais. ... Atualmente, o CEP é composto por oito dígitos, cinco de um lado e três de outro. Cada algarismo do CEP possui um significado.\n",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Address"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Todos os serviços de CEP retornaram erro.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CepError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cep/v2/{cep}": {
+      "get": {
+        "tags": ["CEP V2"],
+        "summary": "Busca por CEP com múltiplos providers e geolocalização.",
+        "description": "Versão 2 do serviço de busca por CEP que inclui informações de geolocalização (latitude e longitude) além dos dados básicos de endereço. Utiliza múltiplos provedores com sistema de fallback para garantir maior disponibilidade.",
+        "parameters": [
+          {
+            "name": "cep",
+            "description": "CEP a ser consultado. Deve conter exatamente 8 dígitos, com ou sem formatação (hífen). Exemplo: 01310-930 ou 01310930.",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{8}$|^[0-9]{5}-[0-9]{3}$",
+              "example": "01310930"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressV2"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "CEP inválido ou mal formatado.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "name": "BadRequestError",
+                  "message": "CEP deve conter exatamente 8 dígitos",
+                  "type": "validation_error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "CEP não encontrado em nenhum provedor.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "name": "NotFoundError",
+                  "message": "CEP NAO ENCONTRADO",
+                  "type": "service_error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Erro interno no serviço de CEP.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "name": "InternalError",
+                  "message": "Erro interno no serviço de CEP",
+                  "type": "internal_error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cep/v3/{cep}": {
+      "get": {
+        "tags": ["CEP V3"],
+        "summary": "Versão 3 do serviço de busca por CEP com múltiplos providers de fallback, com autocomplete de faixas de CEP.",
+        "description": "",
+        "parameters": [
+          {
+            "name": "cep",
+            "description": "O CEP (Código de Endereçamento Postal) é um sistema de códigos que visa racionalizar o processo de encaminhamento e entrega de correspondências através da divisão do país em regiões postais. ... Atualmente, o CEP é composto por oito dígitos, cinco de um lado e três de outro. Cada algarismo do CEP possui um significado.\n",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressV3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Todos os serviços de CEP retornaram erro.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CepError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Coordinates": {
+        "title": "Coordinates",
+        "required": ["longitude", "latitude"],
+        "type": "object",
+        "properties": {
+          "longitude": {
+            "type": "string",
+            "nullable": true
+          },
+          "latitude": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "example": {
+          "longitude": "-49.0629788",
+          "latitude": "-26.9244749"
+        }
+      },
+      "Location": {
+        "title": "Location",
+        "required": ["type", "coordinates"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["Point"]
+          },
+          "coordinates": {
+            "type": "object",
+            "$ref": "#/components/schemas/Coordinates"
+          }
+        },
+        "example": {
+          "type": "Point",
+          "coordinates": {
+            "longitude": "-49.0629788",
+            "latitude": "-26.9244749"
+          }
+        }
+      },
+      "AddressV2": {
+        "title": "Address V2 with Geolocation",
+        "description": "Endereço completo com informações de geolocalização incluídas",
+        "required": [
+          "cep",
+          "state",
+          "city",
+          "neighborhood",
+          "street",
+          "timezoneName",
+          "location"
+        ],
+        "type": "object",
+        "properties": {
+          "cep": {
+            "type": "string",
+            "description": "Código de Endereçamento Postal"
+          },
+          "state": {
+            "type": "string",
+            "description": "Sigla do estado (UF)"
+          },
+          "city": {
+            "type": "string",
+            "description": "Nome da cidade"
+          },
+          "neighborhood": {
+            "type": "string",
+            "nullable": true,
+            "description": "Nome do bairro (pode ser nulo)"
+          },
+          "street": {
+            "type": "string",
+            "nullable": true,
+            "description": "Nome da rua/logradouro (pode ser nulo)"
+          },
+          "timezoneName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Nome da timezone do local (pode ser nulo)"
+          },
+          "location": {
+            "type": "object",
+            "$ref": "#/components/schemas/Location",
+            "description": "Coordenadas geográficas do endereço"
+          },
+          "ibge": {
+            "type": "object",
+            "$ref": "#/components/schemas/IbgeCodes",
+            "description": "Códigos IBGE do município e do estado (podem ser nulos quando o provider não disponibiliza)"
+          }
+        },
+        "example": {
+          "cep": "89010025",
+          "state": "SC",
+          "city": "Blumenau",
+          "neighborhood": "Centro",
+          "street": "Rua Doutor Luiz de Freitas Melro",
+          "timezoneName": "America/Sao_Paulo",
+          "location": {
+            "type": "Point",
+            "coordinates": {
+              "longitude": "-49.0629788",
+              "latitude": "-26.9244749"
+            }
+          },
+          "ibge": {
+            "city": "4202404",
+            "state": "42"
+          }
+        }
+      },
+      "Address": {
+        "title": "Address",
+        "required": [
+          "cep",
+          "state",
+          "city",
+          "neighborhood",
+          "street",
+          "service"
+        ],
+        "type": "object",
+        "properties": {
+          "cep": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "neighborhood": {
+            "type": "string"
+          },
+          "street": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          },
+          "ibge": {
+            "type": "object",
+            "$ref": "#/components/schemas/IbgeCodes",
+            "description": "Códigos IBGE do município e do estado (podem ser nulos quando o provider não disponibiliza)"
+          }
+        },
+        "example": {
+          "cep": "89010025",
+          "state": "SC",
+          "city": "Blumenau",
+          "neighborhood": "Centro",
+          "street": "Rua Doutor Luiz de Freitas Melro",
+          "service": "viacep",
+          "ibge": {
+            "city": "4202404",
+            "state": "42"
+          }
+        }
+      },
+      "IbgeCodes": {
+        "title": "IBGE Codes",
+        "description": "Códigos IBGE associados ao endereço",
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string",
+            "nullable": true,
+            "description": "Código IBGE do município (7 dígitos), pode ser nulo se o provider não disponibiliza"
+          },
+          "state": {
+            "type": "string",
+            "nullable": true,
+            "description": "Código IBGE do estado (2 dígitos), pode ser nulo se a UF não puder ser identificada"
+          }
+        },
+        "example": {
+          "city": "4202404",
+          "state": "42"
+        }
+      },
+      "CepError": {
+        "title": "CepError.",
+        "required": ["name", "message", "type", "errors"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": ""
+          }
+        },
+        "example": {
+          "name": "CepPromiseError",
+          "message": "Todos os serviços de CEP retornaram erro.",
+          "type": "service_error",
+          "errors": [
+            {
+              "name": "ServiceError",
+              "message": "CEP INVÁLIDO",
+              "service": "correios"
+            },
+            {
+              "name": "ServiceError",
+              "message": "CEP não encontrado na base do ViaCEP.",
+              "service": "viacep"
+            }
+          ]
+        }
+      },
+      "Error": {
+        "title": "Error",
+        "required": ["name", "message", "service"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "name": "ServiceError",
+          "message": "CEP INVÁLIDO",
+          "service": "correios"
+        }
+      },
+      "AddressV3": {
+        "title": "Address V3",
+        "description": "Endereço completo com múltiplos providers de fallback e autocomplete de faixas",
+        "required": [
+          "cep",
+          "state",
+          "city",
+          "neighborhood",
+          "street",
+          "timezoneName",
+          "location"
+        ],
+        "type": "object",
+        "properties": {
+          "cep": {
+            "type": "string",
+            "description": "Código de Endereçamento Postal"
+          },
+          "state": {
+            "type": "string",
+            "description": "Sigla do estado (UF)"
+          },
+          "city": {
+            "type": "string",
+            "description": "Nome da cidade"
+          },
+          "neighborhood": {
+            "type": "string",
+            "nullable": true,
+            "description": "Nome do bairro (pode ser nulo)"
+          },
+          "street": {
+            "type": "string",
+            "nullable": true,
+            "description": "Nome da rua/logradouro (pode ser nulo)"
+          },
+          "timezoneName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Nome da timezone do local (pode ser nulo)"
+          },
+          "location": {
+            "type": "object",
+            "$ref": "#/components/schemas/Location",
+            "description": "Coordenadas geográficas do endereço"
+          },
+          "ibge": {
+            "type": "object",
+            "$ref": "#/components/schemas/IbgeCodes",
+            "description": "Códigos IBGE do município e do estado (podem ser nulos quando o provider não disponibiliza)"
+          }
+        },
+        "example": {
+          "cep": "89010025",
+          "state": "SC",
+          "city": "Blumenau",
+          "neighborhood": "Centro",
+          "street": "Rua Doutor Luiz de Freitas Melro",
+          "timezoneName": "America/Sao_Paulo",
+          "location": {
+            "type": "Point",
+            "coordinates": {
+              "longitude": "-49.0629788",
+              "latitude": "-26.9244749"
+            }
+          },
+          "ibge": {
+            "city": "4202404",
+            "state": "42"
+          }
+        }
+      }
+    }
+  }
 }

--- a/pages/docs/doc/holydays.json
+++ b/pages/docs/doc/holydays.json
@@ -1,124 +1,135 @@
 {
-    "tags": [
-        {
-            "name": "Feriados Nacionais",
-            "description": "Consulta de feriados nacionais brasileiros. Calcula automaticamente feriados móveis (como Páscoa, Carnaval) e inclui todos os feriados fixos estabelecidos pela legislação federal."
-        }        
-    ],
-    "paths": {
-        "/feriados/v1/{ano}": {
-            "get": {
-                "tags": ["Feriados Nacionais"],
-                "summary": "Lista os feriados nacionais de determinado ano.",
-                "description": "Retorna a lista completa de feriados nacionais para o ano especificado. Calcula automaticamente os feriados móveis baseados na data da Páscoa e inclui todos os feriados fixos estabelecidos pela legislação brasileira.",
-                "parameters": [
-                    {
-                        "name": "ano",
-                        "description": "Ano para calcular os feriados. Deve ser um número inteiro entre 1900 e 2199.",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 1900,
-                            "maximum": 2199
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Holiday"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Ano não informado.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "BadRequestError",
-                                    "message": "Por favor informe um ano.",
-                                    "type": "validation_error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Ano fora do intervalo suportado.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "BadRequestError",
-                                    "message": "Ano fora do intervalo suportado entre 1900 e 2199.",
-                                    "type": "feriados_range_error"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Erro interno no serviço de feriados.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "InternalError",
-                                    "message": "Erro ao calcular feriados.",
-                                    "type": "feriados_error"
-                                }
-                            }
-                        }
-                    }
-                }
+  "tags": [
+    {
+      "name": "Feriados Nacionais",
+      "description": "Consulta de feriados nacionais brasileiros. Calcula automaticamente feriados móveis (como Páscoa, Carnaval) e inclui todos os feriados fixos estabelecidos pela legislação federal."
+    }
+  ],
+  "paths": {
+    "/feriados/v1/{ano}": {
+      "get": {
+        "tags": ["Feriados Nacionais"],
+        "summary": "Lista os feriados nacionais de determinado ano.",
+        "description": "Retorna a lista completa de feriados nacionais para o ano especificado. Calcula automaticamente os feriados móveis baseados na data da Páscoa e inclui todos os feriados fixos estabelecidos pela legislação brasileira.",
+        "parameters": [
+          {
+            "name": "ano",
+            "description": "Ano para calcular os feriados. Deve ser um número inteiro entre 1900 e 2199.",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1900,
+              "maximum": 2199
             }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Holiday": {
-                "title": "Holiday",
-                "type": "object",
-                "required": ["date", "type", "name"],
-                "properties": {
-                    "date": {
-                        "type": "string",
-                        "format": "date",
-                        "description": "Data do feriado no formato ISO 8601 (YYYY-MM-DD)"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "Tipo do feriado (national, regional, etc.)"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Nome resumido do feriado"
-                    },
-                    "fullName": {
-                        "type": "string",
-                        "description": "Nome completo do feriado (opcional)"
-                    }
+          },
+          {
+            "name": "uf",
+            "description": "Sigla da UF (opcional) para incluir os feriados estaduais. Ex: SP, RJ, MG.",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Holiday"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Ano não informado.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
                 },
                 "example": {
-                    "date": "2021-01-01",
-                    "name": "Confraternização mundial",
-                    "type": "national"
+                  "name": "BadRequestError",
+                  "message": "Por favor informe um ano.",
+                  "type": "validation_error"
                 }
+              }
             }
+          },
+          "404": {
+            "description": "Ano fora do intervalo suportado.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "name": "BadRequestError",
+                  "message": "Ano fora do intervalo suportado entre 1900 e 2199.",
+                  "type": "feriados_range_error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Erro interno no serviço de feriados.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "name": "InternalError",
+                  "message": "Erro ao calcular feriados.",
+                  "type": "feriados_error"
+                }
+              }
+            }
+          }
         }
+      }
     }
+  },
+  "components": {
+    "schemas": {
+      "Holiday": {
+        "title": "Holiday",
+        "type": "object",
+        "required": ["date", "type", "name"],
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Data do feriado no formato ISO 8601 (YYYY-MM-DD)"
+          },
+          "type": {
+            "type": "string",
+            "description": "Tipo do feriado (national, regional, etc.)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Nome resumido do feriado"
+          },
+          "fullName": {
+            "type": "string",
+            "description": "Nome completo do feriado (opcional)"
+          }
+        },
+        "example": {
+          "date": "2021-01-01",
+          "name": "Confraternização mundial",
+          "type": "national"
+        }
+      }
+    }
+  }
 }

--- a/pages/docs/doc/ibge.json
+++ b/pages/docs/doc/ibge.json
@@ -1,651 +1,711 @@
 {
-    "tags": [
-        {
-            "name": "IBGE",
-            "description": "Informações sobre estados Provenientes do IBGE"
-        }
-    ],
-    "paths": {
-        "/ibge/municipios/v1/{siglaUF}": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Retorna os municípios da unidade federativa",
-                "description": "Retorna uma lista de municípios pertencentes à unidade federativa. Cada município contém o nome e o código IBGE correspondente.",
-                "example": "[...]/ibge/municipios/v1/rj?providers=wikipedia",
-                "parameters": [
-                    {
-                        "name": "siglaUF",
-                        "description": "Sigla da unidade federativa, por exemplo SP, RJ, SC, etc.\n",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "string"
-                        }
-                    },
-                    {
-                        "name": "providers",
-                        "description": "Lista de provedores separados por vírgula.<br><strong>Provedores disponíveis:</strong> <ul><li>dados-abertos-br</li><li>gov</li><li>wikipedia</li></ul>",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "format": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successo",
-                        "content": {
-                            "application/json": {
-                                "example": [
-                                    {
-                                        "nome": "Tubarão",
-                                        "codigo_ibge": "421870705"
-                                    },
-                                    {
-                                        "nome": "Tunápolis",
-                                        "codigo_ibge": "421875605"
-                                    },
-                                    {
-                                        "nome": "Turvo",
-                                        "codigo_ibge": "421880605"
-                                    },
-                                    {
-                                        "nome": "Morro Chato",
-                                        "codigo_ibge": "421880620"
-                                    },
-                                    {
-                                        "nome": "União do Oeste",
-                                        "codigo_ibge": "421885505"
-                                    },
-                                    {
-                                        "nome": "Urubici",
-                                        "codigo_ibge": "421890505"
-                                    },
-                                    {
-                                        "nome": "Águas Brancas",
-                                        "codigo_ibge": "421890510"
-                                    },
-                                    {
-                                        "nome": "Santa Teresinha",
-                                        "codigo_ibge": "421890520"
-                                    },
-                                    {
-                                        "nome": "Urupema",
-                                        "codigo_ibge": "421895405"
-                                    },
-                                    {
-                                        "nome": "Urussanga",
-                                        "codigo_ibge": "421900205"
-                                    },
-                                    {
-                                        "nome": "Vargeão",
-                                        "codigo_ibge": "421910105"
-                                    },
-                                    {
-                                        "nome": "Vargem",
-                                        "codigo_ibge": "421915005"
-                                    },
-                                    {
-                                        "nome": "Vargem Bonita",
-                                        "codigo_ibge": "421917605"
-                                    },
-                                    {
-                                        "nome": "Vidal Ramos",
-                                        "codigo_ibge": "421920005"
-                                    },
-                                    {
-                                        "nome": "Videira",
-                                        "codigo_ibge": "421930905"
-                                    },
-                                    {
-                                        "nome": "Anta Gorda",
-                                        "codigo_ibge": "421930910"
-                                    },
-                                    {
-                                        "nome": "Lourdes",
-                                        "codigo_ibge": "421930925"
-                                    },
-                                    {
-                                        "nome": "Vitor Meireles",
-                                        "codigo_ibge": "421935805"
-                                    },
-                                    {
-                                        "nome": "Barra da Prata",
-                                        "codigo_ibge": "421935810"
-                                    },
-                                    {
-                                        "nome": "Witmarsum",
-                                        "codigo_ibge": "421940805"
-                                    },
-                                    {
-                                        "nome": "Xanxerê",
-                                        "codigo_ibge": "421950705"
-                                    },
-                                    {
-                                        "nome": "Cambuinzal",
-                                        "codigo_ibge": "421950715"
-                                    },
-                                    {
-                                        "nome": "Xavantina",
-                                        "codigo_ibge": "421960605"
-                                    },
-                                    {
-                                        "nome": "Linha das Palmeiras",
-                                        "codigo_ibge": "421960610"
-                                    },
-                                    {
-                                        "nome": "Xaxim",
-                                        "codigo_ibge": "421970505"
-                                    },
-                                    {
-                                        "nome": "Anita Garibaldi",
-                                        "codigo_ibge": "421970511"
-                                    },
-                                    {
-                                        "nome": "Diadema",
-                                        "codigo_ibge": "421970516"
-                                    },
-                                    {
-                                        "nome": "Zortéa",
-                                        "codigo_ibge": "421985305"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "UF ausente ou com formato inválido (deve ser exatamente duas letras A–Z)",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "name": "UfBadRequestException",
-                                    "message": "UF inválida. Informe a sigla com duas letras (A-Z).",
-                                    "type": "bad_request"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Sigla com formato válido, mas não corresponde a um estado brasileiro",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "name": "EstadoNotFoundException",
-                                    "message": "UF não encontrada.",
-                                    "type": "not_found"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Parâmetro providers vazio ou com valores não suportados",
-                        "content": {
-                            "application/json": {
-                                "example": {
-                                    "name": "ProvidersInvalidException",
-                                    "message": "Um ou mais providers são inválidos.",
-                                    "type": "unprocessable_entity",
-                                    "errors": [
-                                        "nome-do-provider-invalido"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Erro interno ao consultar os provedores"
-                    }
-                }
-            }
-        },
-        "/ibge/uf/v1": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Retorna informações de todos estados do Brasil",
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/State"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ibge/uf/v1/{code}": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Busca as informações de um estado a partir da sigla ou código",
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/State"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "O código / sigla do estado não foi encontrado",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "NotFoundError",
-                                    "message": "UF não encontrada.",
-                                    "type": "not_found"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ibge/cnae/v1/classes": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Retorna as classes CNAE registradas no IBGE",
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Class"
-                                    }
-                                },
-                                "example": [
-                                    {
-                                        "id": "01113",
-                                        "descricao": "CULTIVO DE CEREAIS",
-                                        "grupo": {
-                                            "id": "011",
-                                            "descricao": "PRODUÇÃO DE LAVOURAS TEMPORÁRIAS",
-                                            "divisao": {
-                                                "id": "01",
-                                                "descricao": "AGRICULTURA, PECUÁRIA E SERVIÇOS RELACIONADOS",
-                                                "secao": {
-                                                    "id": "A",
-                                                    "descricao": "AGRICULTURA, PECUÁRIA, PRODUÇÃO FLORESTAL, PESCA E AQÜICULTURA"
-                                                }
-                                            }
-                                        },
-                                        "observacoes": [
-                                            "Esta classe compreende - o cultivo de alpiste, arroz, aveia, centeio, cevada, milho, milheto, painço, sorgo, trigo, trigo preto, triticale e outros cereais não especificados anteriormente",
-                                            "Esta classe compreende ainda - o beneficiamento de cereais em estabelecimento agrícola, quando atividade complementar ao cultivo\r\n- a produção de sementes de cereais, quando atividade complementar ao cultivo",
-                                            "Esta classe NÃO compreende - a produção de sementes certificadas dos cereais desta classe, inclusive modificadas geneticamente (01.41-5)\r\n- os serviços de preparação de terreno, cultivo e colheita realizados sob contrato (01.61-0)\r\n- o beneficiamento de cereais em estabelecimento agrícola realizado sob contrato (01.63-6)\r\n- o processamento ou beneficiamento de cereais em estabelecimento não-agrícola (grupo 10.4) e (grupo 10.6)\r\n- a produção de biocombustível (19.32-2)"
-                                        ]
-                                    },
-                                    {
-                                        "id": "01121",
-                                        "descricao": "CULTIVO DE ALGODÃO HERBÁCEO E DE OUTRAS FIBRAS DE LAVOURA TEMPORÁRIA",
-                                        "grupo": {
-                                            "id": "011",
-                                            "descricao": "PRODUÇÃO DE LAVOURAS TEMPORÁRIAS",
-                                            "divisao": {
-                                                "id": "01",
-                                                "descricao": "AGRICULTURA, PECUÁRIA E SERVIÇOS RELACIONADOS",
-                                                "secao": {
-                                                    "id": "A",
-                                                    "descricao": "AGRICULTURA, PECUÁRIA, PRODUÇÃO FLORESTAL, PESCA E AQÜICULTURA"
-                                                }
-                                            }
-                                        },
-                                        "observacoes": [
-                                            "Esta classe compreende - o cultivo de algodão herbáceo\r\n- o cultivo de juta, junco, linho, malva, rami, sorgo vassoura e outras fibras de lavoura temporária não especificadas anteriormente",
-                                            "Esta classe compreende ainda - o descaroçamento do algodão, quando atividade complementar ao cultivo\r\n- o processo de maceração e secagem das fibras desta classe\r\n- a produção de sementes e mudas das fibras desta classe, quando atividade complementar ao cultivo",
-                                            "Esta classe NÃO compreende - o cultivo de algodão arbóreo (01.39-3)\r\n- a produção de sementes e mudas certificadas das fibras desta classe, inclusive modificadas geneticamente (grupo 01.4)\r\n- os serviços de preparação de terreno, cultivo e colheita realizados sob contrato (01.61-0)\r\n- o serviço de descaroçamento de algodão realizado sob contrato (01.63-6)\r\n- a preparação do algodão e de outras fibras de lavoura temporária, em estabelecimento não-agrícola (13.11-1) e (13.12-0)"
-                                        ]
-                                    },
-                                    {
-                                        "id": "01130",
-                                        "descricao": "CULTIVO DE CANA-DE-AÇÚCAR",
-                                        "grupo": {
-                                            "id": "011",
-                                            "descricao": "PRODUÇÃO DE LAVOURAS TEMPORÁRIAS",
-                                            "divisao": {
-                                                "id": "01",
-                                                "descricao": "AGRICULTURA, PECUÁRIA E SERVIÇOS RELACIONADOS",
-                                                "secao": {
-                                                    "id": "A",
-                                                    "descricao": "AGRICULTURA, PECUÁRIA, PRODUÇÃO FLORESTAL, PESCA E AQÜICULTURA"
-                                                }
-                                            }
-                                        },
-                                        "observacoes": [
-                                            "Esta classe compreende - o cultivo de cana-de-açúcar",
-                                            "Esta classe compreende ainda - a produção de toletes (mudas) de cana-de-açúcar, quando atividade complementar ao cultivo",
-                                            "Esta classe NÃO compreende - a produção de toletes (mudas) certificadas de cana-de-açúcar, inclusive modificadas geneticamente (01.42-3)\r\n- os serviços de preparação de terreno, cultivo e corte da cana realizados sob contrato (01.61-0)\r\n- a produção de açúcar em bruto (usinas de açúcar) (10.71-6)\r\n- a fabricação, refino e moagem de açúcar de cana (10.72-4)\r\n- a produção de álcool de cana (19.31-4)"
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ibge/cnae/v1/classes/{codigoClasse}": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Busca as classes CNAE a partir do código da classe",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "codigoClasse",
-                        "description": "Código da Classe CNAE como 01113",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Class"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Classe CNAE não encontrada.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "message": "Classe CNAE não encontrada.",
-                                    "type": "not_found",
-                                    "name": "NotFoundError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ibge/cnae/v1/divisoes/{codigoDivisao}": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Busca as classes CNAE a partir do código da divisão",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "codigoDivisao",
-                        "description": "Código da divisão CNAE como 99, 01, 05...",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Class"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Divisão CNAE não encontrada.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "message": "Divisão CNAE não encontrada.",
-                                    "type": "not_found",
-                                    "name": "NotFoundError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ibge/cnae/v1/grupos/{codigoGrupos}": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Busca as classes CNAE a partir do código do grupo",
-                "description": "",
-                "parameters": [
-                    {
-                        "name": "codigoGrupo",
-                        "description": "Código do grupo CNAE como 990, 239, etc.",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Class"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Grupo CNAE não encontrado.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "message": "Grupo CNAE não encontrado.",
-                                    "type": "not_found",
-                                    "name": "NotFoundError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ibge/regioes/v1/{region}": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Busca as informações de uma região à partir da sigla ou código",
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/State"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "O código / sigla da região não foi encontrado",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorMessage"
-                                },
-                                "example": {
-                                    "name": "NotFoundError",
-                                    "message": "Região não encontrada.",
-                                    "type": "not_found"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/ibge/regioes/v1": {
-            "get": {
-                "tags": [
-                    "IBGE"
-                ],
-                "summary": "Retorna as informações das regiões do Brasil",
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Region"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "State": {
-                "title": "State",
-                "required": [
-                    "id",
-                    "sigla",
-                    "nome",
-                    "regiao"
-                ],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "sigla": {
-                        "type": "string"
-                    },
-                    "nome": {
-                        "type": "string"
-                    },
-                    "regiao": {
-                        "type": "object",
-                        "$ref": "#/components/schemas/Region"
-                    },
-                    "populacao_estimada": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true,
-                        "description": "Estimativa populacional mais recente do IBGE"
-                    },
-                    "periodo": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Ano de referência da estimativa populacional"
-                    }
-                },
-                "example": {
-                    "id": 35,
-                    "sigla": "SP",
-                    "nome": "São Paulo",
-                    "regiao": {
-                        "id": 3,
-                        "sigla": "SE",
-                        "nome": "Sudeste"
-                    },
-                    "populacao_estimada": 45969144,
-                    "periodo": "2024"
-                }
-            },
-            "Region": {
-                "title": "Region",
-                "required": [
-                    "id",
-                    "sigla",
-                    "nome"
-                ],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "sigla": {
-                        "type": "string"
-                    },
-                    "nome": {
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "id": 3,
-                    "sigla": "SE",
-                    "nome": "Sudeste"
-                }
-            }
-        }
+  "tags": [
+    {
+      "name": "IBGE",
+      "description": "Informações sobre estados Provenientes do IBGE"
     }
+  ],
+  "paths": {
+    "/ibge/municipios/v1/{siglaUF}": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Retorna os municípios da unidade federativa",
+        "description": "Retorna uma lista de municípios pertencentes à unidade federativa. Cada município contém o nome e o código IBGE correspondente.",
+        "example": "[...]/ibge/municipios/v1/rj?providers=wikipedia",
+        "parameters": [
+          {
+            "name": "siglaUF",
+            "description": "Sigla da unidade federativa, por exemplo SP, RJ, SC, etc.\n",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          },
+          {
+            "name": "providers",
+            "description": "Lista de provedores separados por vírgula.<br><strong>Provedores disponíveis:</strong> <ul><li>dados-abertos-br</li><li>gov</li><li>wikipedia</li></ul>",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successo",
+            "content": {
+              "application/json": {
+                "example": [
+                  {
+                    "nome": "Tubarão",
+                    "codigo_ibge": "421870705"
+                  },
+                  {
+                    "nome": "Tunápolis",
+                    "codigo_ibge": "421875605"
+                  },
+                  {
+                    "nome": "Turvo",
+                    "codigo_ibge": "421880605"
+                  },
+                  {
+                    "nome": "Morro Chato",
+                    "codigo_ibge": "421880620"
+                  },
+                  {
+                    "nome": "União do Oeste",
+                    "codigo_ibge": "421885505"
+                  },
+                  {
+                    "nome": "Urubici",
+                    "codigo_ibge": "421890505"
+                  },
+                  {
+                    "nome": "Águas Brancas",
+                    "codigo_ibge": "421890510"
+                  },
+                  {
+                    "nome": "Santa Teresinha",
+                    "codigo_ibge": "421890520"
+                  },
+                  {
+                    "nome": "Urupema",
+                    "codigo_ibge": "421895405"
+                  },
+                  {
+                    "nome": "Urussanga",
+                    "codigo_ibge": "421900205"
+                  },
+                  {
+                    "nome": "Vargeão",
+                    "codigo_ibge": "421910105"
+                  },
+                  {
+                    "nome": "Vargem",
+                    "codigo_ibge": "421915005"
+                  },
+                  {
+                    "nome": "Vargem Bonita",
+                    "codigo_ibge": "421917605"
+                  },
+                  {
+                    "nome": "Vidal Ramos",
+                    "codigo_ibge": "421920005"
+                  },
+                  {
+                    "nome": "Videira",
+                    "codigo_ibge": "421930905"
+                  },
+                  {
+                    "nome": "Anta Gorda",
+                    "codigo_ibge": "421930910"
+                  },
+                  {
+                    "nome": "Lourdes",
+                    "codigo_ibge": "421930925"
+                  },
+                  {
+                    "nome": "Vitor Meireles",
+                    "codigo_ibge": "421935805"
+                  },
+                  {
+                    "nome": "Barra da Prata",
+                    "codigo_ibge": "421935810"
+                  },
+                  {
+                    "nome": "Witmarsum",
+                    "codigo_ibge": "421940805"
+                  },
+                  {
+                    "nome": "Xanxerê",
+                    "codigo_ibge": "421950705"
+                  },
+                  {
+                    "nome": "Cambuinzal",
+                    "codigo_ibge": "421950715"
+                  },
+                  {
+                    "nome": "Xavantina",
+                    "codigo_ibge": "421960605"
+                  },
+                  {
+                    "nome": "Linha das Palmeiras",
+                    "codigo_ibge": "421960610"
+                  },
+                  {
+                    "nome": "Xaxim",
+                    "codigo_ibge": "421970505"
+                  },
+                  {
+                    "nome": "Anita Garibaldi",
+                    "codigo_ibge": "421970511"
+                  },
+                  {
+                    "nome": "Diadema",
+                    "codigo_ibge": "421970516"
+                  },
+                  {
+                    "nome": "Zortéa",
+                    "codigo_ibge": "421985305"
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "UF ausente ou com formato inválido (deve ser exatamente duas letras A–Z)",
+            "content": {
+              "application/json": {
+                "example": {
+                  "name": "UfBadRequestException",
+                  "message": "UF inválida. Informe a sigla com duas letras (A-Z).",
+                  "type": "bad_request"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Sigla com formato válido, mas não corresponde a um estado brasileiro",
+            "content": {
+              "application/json": {
+                "example": {
+                  "name": "EstadoNotFoundException",
+                  "message": "UF não encontrada.",
+                  "type": "not_found"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Parâmetro providers vazio ou com valores não suportados",
+            "content": {
+              "application/json": {
+                "example": {
+                  "name": "ProvidersInvalidException",
+                  "message": "Um ou mais providers são inválidos.",
+                  "type": "unprocessable_entity",
+                  "errors": ["nome-do-provider-invalido"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Erro interno ao consultar os provedores"
+          }
+        }
+      }
+    },
+    "/ibge/uf/v1": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Retorna informações de todos estados do Brasil",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/State"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ibge/uf/v1/{code}": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Busca as informações de um estado a partir da sigla ou código",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/State"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "O código / sigla do estado não foi encontrado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "name": "NotFoundError",
+                  "message": "UF não encontrada.",
+                  "type": "not_found"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ibge/cnae/v1/classes": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Retorna as classes CNAE registradas no IBGE",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Class"
+                  }
+                },
+                "example": [
+                  {
+                    "id": "01113",
+                    "descricao": "CULTIVO DE CEREAIS",
+                    "grupo": {
+                      "id": "011",
+                      "descricao": "PRODUÇÃO DE LAVOURAS TEMPORÁRIAS",
+                      "divisao": {
+                        "id": "01",
+                        "descricao": "AGRICULTURA, PECUÁRIA E SERVIÇOS RELACIONADOS",
+                        "secao": {
+                          "id": "A",
+                          "descricao": "AGRICULTURA, PECUÁRIA, PRODUÇÃO FLORESTAL, PESCA E AQÜICULTURA"
+                        }
+                      }
+                    },
+                    "observacoes": [
+                      "Esta classe compreende - o cultivo de alpiste, arroz, aveia, centeio, cevada, milho, milheto, painço, sorgo, trigo, trigo preto, triticale e outros cereais não especificados anteriormente",
+                      "Esta classe compreende ainda - o beneficiamento de cereais em estabelecimento agrícola, quando atividade complementar ao cultivo\r\n- a produção de sementes de cereais, quando atividade complementar ao cultivo",
+                      "Esta classe NÃO compreende - a produção de sementes certificadas dos cereais desta classe, inclusive modificadas geneticamente (01.41-5)\r\n- os serviços de preparação de terreno, cultivo e colheita realizados sob contrato (01.61-0)\r\n- o beneficiamento de cereais em estabelecimento agrícola realizado sob contrato (01.63-6)\r\n- o processamento ou beneficiamento de cereais em estabelecimento não-agrícola (grupo 10.4) e (grupo 10.6)\r\n- a produção de biocombustível (19.32-2)"
+                    ]
+                  },
+                  {
+                    "id": "01121",
+                    "descricao": "CULTIVO DE ALGODÃO HERBÁCEO E DE OUTRAS FIBRAS DE LAVOURA TEMPORÁRIA",
+                    "grupo": {
+                      "id": "011",
+                      "descricao": "PRODUÇÃO DE LAVOURAS TEMPORÁRIAS",
+                      "divisao": {
+                        "id": "01",
+                        "descricao": "AGRICULTURA, PECUÁRIA E SERVIÇOS RELACIONADOS",
+                        "secao": {
+                          "id": "A",
+                          "descricao": "AGRICULTURA, PECUÁRIA, PRODUÇÃO FLORESTAL, PESCA E AQÜICULTURA"
+                        }
+                      }
+                    },
+                    "observacoes": [
+                      "Esta classe compreende - o cultivo de algodão herbáceo\r\n- o cultivo de juta, junco, linho, malva, rami, sorgo vassoura e outras fibras de lavoura temporária não especificadas anteriormente",
+                      "Esta classe compreende ainda - o descaroçamento do algodão, quando atividade complementar ao cultivo\r\n- o processo de maceração e secagem das fibras desta classe\r\n- a produção de sementes e mudas das fibras desta classe, quando atividade complementar ao cultivo",
+                      "Esta classe NÃO compreende - o cultivo de algodão arbóreo (01.39-3)\r\n- a produção de sementes e mudas certificadas das fibras desta classe, inclusive modificadas geneticamente (grupo 01.4)\r\n- os serviços de preparação de terreno, cultivo e colheita realizados sob contrato (01.61-0)\r\n- o serviço de descaroçamento de algodão realizado sob contrato (01.63-6)\r\n- a preparação do algodão e de outras fibras de lavoura temporária, em estabelecimento não-agrícola (13.11-1) e (13.12-0)"
+                    ]
+                  },
+                  {
+                    "id": "01130",
+                    "descricao": "CULTIVO DE CANA-DE-AÇÚCAR",
+                    "grupo": {
+                      "id": "011",
+                      "descricao": "PRODUÇÃO DE LAVOURAS TEMPORÁRIAS",
+                      "divisao": {
+                        "id": "01",
+                        "descricao": "AGRICULTURA, PECUÁRIA E SERVIÇOS RELACIONADOS",
+                        "secao": {
+                          "id": "A",
+                          "descricao": "AGRICULTURA, PECUÁRIA, PRODUÇÃO FLORESTAL, PESCA E AQÜICULTURA"
+                        }
+                      }
+                    },
+                    "observacoes": [
+                      "Esta classe compreende - o cultivo de cana-de-açúcar",
+                      "Esta classe compreende ainda - a produção de toletes (mudas) de cana-de-açúcar, quando atividade complementar ao cultivo",
+                      "Esta classe NÃO compreende - a produção de toletes (mudas) certificadas de cana-de-açúcar, inclusive modificadas geneticamente (01.42-3)\r\n- os serviços de preparação de terreno, cultivo e corte da cana realizados sob contrato (01.61-0)\r\n- a produção de açúcar em bruto (usinas de açúcar) (10.71-6)\r\n- a fabricação, refino e moagem de açúcar de cana (10.72-4)\r\n- a produção de álcool de cana (19.31-4)"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ibge/cnae/v1/classes/{codigoClasse}": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Busca as classes CNAE a partir do código da classe",
+        "description": "",
+        "parameters": [
+          {
+            "name": "codigoClasse",
+            "description": "Código da Classe CNAE como 01113",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Class"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Classe CNAE não encontrada.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "message": "Classe CNAE não encontrada.",
+                  "type": "not_found",
+                  "name": "NotFoundError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ibge/cnae/v1/divisoes/{codigoDivisao}": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Busca as classes CNAE a partir do código da divisão",
+        "description": "",
+        "parameters": [
+          {
+            "name": "codigoDivisao",
+            "description": "Código da divisão CNAE como 99, 01, 05...",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Class"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Divisão CNAE não encontrada.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "message": "Divisão CNAE não encontrada.",
+                  "type": "not_found",
+                  "name": "NotFoundError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ibge/cnae/v1/grupos/{codigoGrupos}": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Busca as classes CNAE a partir do código do grupo",
+        "description": "",
+        "parameters": [
+          {
+            "name": "codigoGrupo",
+            "description": "Código do grupo CNAE como 990, 239, etc.",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Class"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Grupo CNAE não encontrado.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "message": "Grupo CNAE não encontrado.",
+                  "type": "not_found",
+                  "name": "NotFoundError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ibge/regioes/v1/{region}": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Busca as informações de uma região à partir da sigla ou código",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/State"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "O código / sigla da região não foi encontrado",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                },
+                "example": {
+                  "name": "NotFoundError",
+                  "message": "Região não encontrada.",
+                  "type": "not_found"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ibge/regioes/v1": {
+      "get": {
+        "tags": ["IBGE"],
+        "summary": "Retorna as informações das regiões do Brasil",
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Region"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "State": {
+        "title": "State",
+        "required": ["id", "sigla", "nome", "regiao"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sigla": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "regiao": {
+            "type": "object",
+            "$ref": "#/components/schemas/Region"
+          },
+          "populacao_estimada": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "Estimativa populacional mais recente do IBGE"
+          },
+          "periodo": {
+            "type": "string",
+            "nullable": true,
+            "description": "Ano de referência da estimativa populacional"
+          }
+        },
+        "example": {
+          "id": 35,
+          "sigla": "SP",
+          "nome": "São Paulo",
+          "regiao": {
+            "id": 3,
+            "sigla": "SE",
+            "nome": "Sudeste"
+          },
+          "populacao_estimada": 45969144,
+          "periodo": "2024"
+        }
+      },
+      "Region": {
+        "title": "Region",
+        "required": ["id", "sigla", "nome"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sigla": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "id": 3,
+          "sigla": "SE",
+          "nome": "Sudeste"
+        }
+      },
+      "Group": {
+        "title": "Group",
+        "required": ["id", "descricao", "divisao"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": "string"
+          },
+          "divisao": {
+            "type": "object",
+            "$ref": "#/components/schemas/Division"
+          }
+        }
+      },
+      "Section": {
+        "title": "Section",
+        "required": ["id", "descricao"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": "string"
+          }
+        }
+      },
+      "Division": {
+        "title": "Division",
+        "required": ["id", "descricao", "secao"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": "string"
+          },
+          "secao": {
+            "type": "object",
+            "$ref": "#/components/schemas/Section"
+          }
+        }
+      },
+      "Class": {
+        "title": "Class",
+        "required": ["id", "divisao", "descricao", "grupo", "observacoes"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": "string"
+          },
+          "grupo": {
+            "type": "object",
+            "$ref": "#/components/schemas/Group"
+          },
+          "observacoes": {
+            "type": "array",
+            "format": "string"
+          }
+        },
+        "example": {
+          "id": "99008",
+          "descricao": "ORGANISMOS INTERNACIONAIS E OUTRAS INSTITUIÇÕES EXTRATERRITORIAIS",
+          "grupo": {
+            "id": "990",
+            "descricao": "ORGANISMOS INTERNACIONAIS E OUTRAS INSTITUIÇÕES EXTRATERRITORIAIS",
+            "divisao": {
+              "id": "99",
+              "descricao": "ORGANISMOS INTERNACIONAIS E OUTRAS INSTITUIÇÕES EXTRATERRITORIAIS",
+              "secao": {
+                "id": "U",
+                "descricao": "ORGANISMOS INTERNACIONAIS E OUTRAS INSTITUIÇÕES EXTRATERRITORIAIS"
+              }
+            }
+          },
+          "observacoes": [
+            "Esta classe compreende - as atividades de embaixadas e consulados estrangeiros no Brasil\r\n- as atividades exercidas no Brasil por representantes de organizações internacionais, tais como: as Organizações das Nações Unidas - ONU e de suas agências especializadas e regionais, o Banco Mundial, o Fundo Monetário Internacional - FMI, o Banco Interamericano de Desenvolvimento - BID, a Organização para a Cooperação e Desenvolvimento Econômico - OCDE, a Organização dos Países Exportadores de Petróleo - OPEP, a Comunidade Européia, etc.",
+            "Esta classe compreende ainda - as atividades de missões diplomáticas e consulares quando determinadas pelo país em que estão localizadas e não pelo país que representam",
+            "Esta classe NÃO compreende - as atividades de consulados e embaixadas brasileiras no exterior (84.21-3)\r\n- as atividades de organismos públicos estrangeiros atuando no Brasil sem status diplomático que são classificados nas atividades correspondentes"
+          ]
+        }
+      }
+    }
+  }
 }

--- a/tests/docs-spec-refs.test.js
+++ b/tests/docs-spec-refs.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getJsonDoc } from '@/services/getJsonDoc';
+
+describe('spec OpenAPI completa (docs)', () => {
+  it('todas as refs #/components/schemas resolvem', () => {
+    const spec = getJsonDoc();
+    const schemas = spec.components?.schemas || {};
+    const names = Object.keys(schemas);
+    expect(names.length).toBeGreaterThan(30);
+
+    const broken = [];
+    const walk = (obj) => {
+      if (!obj || typeof obj !== 'object') return;
+      if (typeof obj.$ref === 'string' && obj.$ref.startsWith('#/components/schemas/')) {
+        const n = obj.$ref.split('/').pop();
+        if (!schemas[n]) broken.push(obj.$ref);
+      }
+      for (const v of Object.values(obj)) walk(v);
+    };
+    walk(spec);
+    expect(broken).toEqual([]);
+  });
+});

--- a/tests/feriados-v1.test.js
+++ b/tests/feriados-v1.test.js
@@ -182,6 +182,40 @@ describe('/feriados/v1 (E2E)', () => {
     );
     expect(allWeekdaysValid).toBe(true);
   });
+
+  test('Com uf válida (SP): retorna feriados estaduais', async () => {
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2026?uf=SP`;
+    const { data } = await axios.get(requestUrl);
+
+    const stateHolidays = data.filter((holiday) => holiday.type === 'state');
+
+    expect(stateHolidays.length).toBeGreaterThan(0);
+    expect(stateHolidays.every((h) => h.state === 'SP')).toBe(true);
+    expect(stateHolidays[0]).toMatchObject({
+      date: '2026-01-25',
+      name: 'Aniversário da Cidade de São Paulo',
+      type: 'state',
+      state: 'SP',
+    });
+  });
+
+  test('Com uf inválida (XX): erro 400', async () => {
+    expect.assertions(2);
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2026?uf=XX`;
+
+    try {
+      await axios.get(requestUrl);
+    } catch (error) {
+      const { response } = error;
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual({
+        message: 'UF inválida. Informe uma sigla válida (ex: SP, RJ, MG).',
+        type: 'invalid_uf',
+        name: 'BadRequestError',
+      });
+    }
+  });
 });
 
 testCorsForRoute('/api/feriados/v1/2020');

--- a/tests/holidays-uf-fix.test.js
+++ b/tests/holidays-uf-fix.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import getHolidays from '@/services/holidays';
+
+describe('getHolidays com UF (fix rota feriados)', () => {
+  it('retorna feriado estadual de SP quando uf=SP', () => {
+    const result = getHolidays(2026, 'SP');
+    const state = result.filter((h) => h.type === 'state');
+    expect(state.length).toBeGreaterThan(0);
+    expect(state.every((h) => h.state === 'SP')).toBe(true);
+    expect(state[0]).toEqual({
+      date: '2026-01-25',
+      name: 'Aniversário da Cidade de São Paulo',
+      type: 'state',
+      state: 'SP',
+    });
+  });
+
+  it('não retorna estaduais sem UF', () => {
+    const result = getHolidays(2026);
+    expect(result.some((h) => h.type === 'state')).toBe(false);
+  });
+
+  it('lança erro para UF inválida', () => {
+    expect(() => getHolidays(2026, 'XX')).toThrow('Estado inválido');
+  });
+});


### PR DESCRIPTION
## 🗂️ Dois fixes neste PR

### 1. Feriados estaduais expostos na rota
O #866 implementou a lógica no service (`getHolidays(year, state)`) mas a rota não repassava o parâmetro UF. Issues #625/#541.
- `[ano].js`: lê `query.uf` → `getHolidays(ano, uf)`; UF inválida → **400 JSON** (`invalid_uf`)
- `holydays.json`: param `uf` opcional na doc
- Testes: `uf=SP` → feriado estadual; `uf=XX` → 400

### 2. Docs quebradas (Invalid reference token: Class)
`brasilapi.com.br/docs` quebrava no Redoc. Os rebases #862 (CNAE) e #867 (CEP v3) trouxeram refs `#/components/schemas/Class` (4×) e `AddressV3` **sem as definições dos schemas**.
- `ibge.json`: adiciona schemas `Class`/`Group`/`Section`/`Division` (do PR original #361)
- `cep.json`: adiciona schema `AddressV3` (derivado do AddressV2, mesmo shape)
- Teste preventivo: `docs-spec-refs.test.js` valida que todas as refs resolvem

## Verificação
- 7/7 testes de feriados + 1/1 teste de refs
- Lint: 0 erros