### PR TITLE
fix: workflows de snapshot usam create-pull-request (branch main protegida)

### DIFF
--- a/.github/workflows/banks-headquarters-snapshot.yml
+++ b/.github/workflows/banks-headquarters-snapshot.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   banks-headquarters-snapshot:
@@ -48,7 +49,11 @@ jobs:
             services/banco-central/snapshots/*.json
           if-no-files-found: error
 
-      - name: Commitar snapshot versionado e latest
+      # git add + guard ANTES da action: se nada mudou, exit 0 silencioso.
+      # A action só abre PR quando há diff staged (dados realmente mudaram).
+      # A branch main tem proteção (GH006: Protected branch update failed),
+      # então o push direto falha — abrimos um PR com o snapshot atualizado.
+      - name: Preparar mudancas do snapshot
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -60,5 +65,18 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore(banks): atualiza snapshot semanal de enderecos"
-          git push
+      - name: Abrir PR com snapshot atualizado
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(banks): atualiza snapshot semanal de enderecos'
+          branch: chore/banks-snapshot-update
+          delete-branch: true
+          title: 'chore(banks): atualiza snapshot semanal de enderecos'
+          body: |
+            Atualização automática do snapshot semanal de endereços dos bancos
+            (workflow `Snapshot Enderecos Bancos`).
+
+            Quando não há mudança de dados, nenhum PR é aberto.
+          labels: automated

--- a/.github/workflows/pix-participants-snapshot.yml
+++ b/.github/workflows/pix-participants-snapshot.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   pix-participants-snapshot:
@@ -42,7 +43,11 @@ jobs:
       - name: Gerar snapshot de participantes do Pix
         run: npm run snapshot:pix:participants
 
-      - name: Commitar snapshot atualizado
+      # git add + guard ANTES da action: se nada mudou, exit 0 silencioso.
+      # A action só abre PR quando há diff staged (dados realmente mudaram).
+      # A branch main tem proteção (GH006: Protected branch update failed),
+      # então o push direto falha — abrimos um PR com o snapshot atualizado.
+      - name: Preparar mudancas do snapshot
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -54,5 +59,18 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore(pix): atualiza snapshot de participantes do Pix"
-          git push
+      - name: Abrir PR com snapshot atualizado
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(pix): atualiza snapshot de participantes do Pix'
+          branch: chore/pix-snapshot-update
+          delete-branch: true
+          title: 'chore(pix): atualiza snapshot de participantes do Pix'
+          body: |
+            Atualização automática do snapshot de participantes do Pix
+            (workflow `Snapshot Participantes Pix`).
+
+            Quando não há mudança de dados, nenhum PR é aberto.
+          labels: automated


### PR DESCRIPTION
Os workflows de snapshot agendados faziam `git commit && git push` direto na `main`, que tem branch protection desde 2026 → falham com `GH006: Protected branch update failed`.\n\n### Correção\n| Workflow | Status |\n|---|---|\n| `banks-headquarters-snapshot.yml` (#876) | **já falhava** semanalmente (10/08 e 17/08) |\n| `pix-participants-snapshot.yml` (#892) | falharia no 1º agendamento com mudança de dados |\n\n### Padrão aplicado\nBloco `commit+push` → `peter-evans/create-pull-request@v6` com guard `exit 0` quando não há diff staged:\n- Snapshot sem mudança → workflow fica **silencioso**\n- Snapshot com mudança → abre **PR** para o maintainer aprovar/mergear\n- Requisitos: `permissions: contents: write` + `pull-requests: write`