### PR TITLE
fix(feriados): reclassifica Carnaval e Corpus Christi como pontos facultativos (Lei 9.093/1995)

### DIFF
--- a/pages/docs/doc/holydays.json
+++ b/pages/docs/doc/holydays.json
@@ -140,7 +140,12 @@
                     },
                     "type": {
                         "type": "string",
-                        "description": "Tipo do feriado (national, regional, etc.)"
+                        "enum": [
+                            "national",
+                            "state",
+                            "facultative"
+                        ],
+                        "description": "Tipo do feriado (national, state, facultative)"
                     },
                     "name": {
                         "type": "string",

--- a/services/holidays/index.js
+++ b/services/holidays/index.js
@@ -149,7 +149,7 @@ export function getEasterHolidays(year) {
   holidays.push({
     date: formatDate(movingDate),
     name: 'Carnaval',
-    type: 'national',
+    type: 'facultative',
     weekday: getWeekdayName(formatDate(movingDate)),
   });
   movingDate.setDate(movingDate.getDate() + 1);
@@ -157,7 +157,7 @@ export function getEasterHolidays(year) {
   holidays.push({
     date: carnavalDate,
     name: 'Carnaval',
-    type: 'national',
+    type: 'facultative',
     weekday: getWeekdayName(carnavalDate),
   });
   movingDate.setDate(movingDate.getDate() + 107);
@@ -165,7 +165,7 @@ export function getEasterHolidays(year) {
   holidays.push({
     date: corpusChristiDate,
     name: 'Corpus Christi',
-    type: 'national',
+    type: 'facultative',
     weekday: getWeekdayName(corpusChristiDate),
   });
   return holidays;

--- a/tests/feriados-v1.test.js
+++ b/tests/feriados-v1.test.js
@@ -199,6 +199,28 @@ describe('/feriados/v1 (E2E)', () => {
     });
   });
 
+  test('Carnaval e Corpus Christi retornam type "facultative"; Páscoa e Sexta-feira Santa "national"', async () => {
+    expect.assertions(4);
+    const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2020`;
+    const { data } = await axios.get(requestUrl);
+
+    const carnaval = data.filter((holiday) => holiday.name === 'Carnaval');
+    const corpusChristi = data.find(
+      (holiday) => holiday.name === 'Corpus Christi'
+    );
+    const pascoa = data.find((holiday) => holiday.name === 'Páscoa');
+    const sextaSanta = data.find(
+      (holiday) => holiday.name === 'Sexta-feira Santa'
+    );
+
+    expect(carnaval.every((holiday) => holiday.type === 'facultative')).toBe(
+      true
+    );
+    expect(corpusChristi.type).toBe('facultative');
+    expect(pascoa.type).toBe('national');
+    expect(sextaSanta.type).toBe('national');
+  });
+
   test('Com uf inválida (XX): erro 400', async () => {
     expect.assertions(2);
     const requestUrl = `${global.SERVER_URL}/api/feriados/v1/2026?uf=XX`;

--- a/tests/feriados/getHolidays.test.js
+++ b/tests/feriados/getHolidays.test.js
@@ -63,4 +63,32 @@ describe('getHolidays - feriados estaduais', () => {
 
     expect(chamarFuncao).toThrowError('Estado inválido');
   });
+
+  test('Carnaval e Corpus Christi são pontos facultativos; Páscoa e Sexta-feira Santa seguem nacionais (Lei 9.093/1995)', () => {
+    const year = 2024;
+
+    const result = getHolidays(year);
+
+    const carnaval = result.filter((holiday) => holiday.name === 'Carnaval');
+    const corpusChristi = result.find(
+      (holiday) => holiday.name === 'Corpus Christi'
+    );
+    const pascoa = result.find((holiday) => holiday.name === 'Páscoa');
+    const sextaSanta = result.find(
+      (holiday) => holiday.name === 'Sexta-feira Santa'
+    );
+
+    // Carnaval são dois dias (segunda e terça) e ambos são facultativos
+    expect(carnaval).toHaveLength(2);
+    expect(carnaval.every((holiday) => holiday.type === 'facultative')).toBe(
+      true
+    );
+
+    expect(corpusChristi).toBeDefined();
+    expect(corpusChristi.type).toBe('facultative');
+
+    // Páscoa e Sexta-feira Santa permanecem nacionais
+    expect(pascoa.type).toBe('national');
+    expect(sextaSanta.type).toBe('national');
+  });
 });

--- a/tests/helpers/feriados/index.js
+++ b/tests/helpers/feriados/index.js
@@ -57,7 +57,7 @@ const getEasterHolidays = (year, holidaysName = easterHolidaysName) =>
     ...(carnavalDaysByYear[year] || []).map((date) => ({
       date,
       name: 'Carnaval',
-      type: 'national',
+      type: 'facultative',
       weekday: getWeekdayName(date),
     })),
     {
@@ -75,7 +75,7 @@ const getEasterHolidays = (year, holidaysName = easterHolidaysName) =>
     {
       date: corpusChristiDaysByYear[year],
       name: 'Corpus Christi',
-      type: 'national',
+      type: 'facultative',
       weekday: getWeekdayName(corpusChristiDaysByYear[year]),
     },
   ].filter(({ name }) => holidaysName.includes(name));


### PR DESCRIPTION
Closes #411

## Mudança
Carnaval (2 dias, segunda e terça) e Corpus Christi passam de `type: "national"` para **`type: "facultative"`** no `/api/feriados/v1/{ano}` — legalmente são pontos facultativos (Lei 9.093/1995), não feriados nacionais.

- `services/holidays/index.js`: reclassifica os 3 registros (Carnaval ×2 + Corpus Christi). Páscoa e Sexta-feira Santa **permanecem** `national`.
- Datas inalteradas — apenas o `type` muda.
- Doc `holydays.json`: enum do campo `type` atualizado (`national`, `state`, `facultative`) — edição cirúrgica.

## Compatibilidade
- `/diasuteis/v1` casa feriado por **data** (não por `type`) → sem quebra.
- Nenhum consumidor interno filtra por `type === 'national'` (verificado por grep em `services/ pages/ lib/ util/`).
- Quem usa `type === 'national'` para calcular dias úteis passa a tratar Carnaval/Corpus Christi corretamente (comportamento legalmente correto).

## Testes (TDD)
- **Unit** (`tests/feriados/getHolidays.test.js`): Carnaval/Corpus Christi → `facultative`; Páscoa/Sexta Santa → `national`.
- **E2E de rota** (`tests/feriados-v1.test.js`): mesmo contrato via HTTP.
- Fixture `tests/helpers/feriados/index.js` sincronizada (E2E compara contra ela com `toEqual`).
- Docs refs (`tests/docs-spec-refs.test.js`) verde; ESLint verde nos arquivos modificados quanto às linhas novas.

> Obs. (não relacionado a esta PR): 2 falhas locais de `/diasuteis/v1` vêm de bug de fuso pré-existente (getDay/getDate locais vs `toISOString` UTC — falha só em host UTC-3, CI roda UTC) e 1 do provider ISBN (ambiental). Fica o registro para PR de estabilidade separada.