### PR TITLE
fix(docs): preserva o prefixo /api na URL base da spec OpenAPI

### DIFF
--- a/pages/docs/doc/eleicoes.json
+++ b/pages/docs/doc/eleicoes.json
@@ -5,11 +5,6 @@
         "version": "1.0.0",
         "description": "Documentação dos endpoints de eleições integrados à API DivulgaCandContas do TSE."
     },
-    "servers": [
-        {
-            "url": "https://brasilapi.com.br"
-        }
-    ],
     "tags": [
         {
             "name": "Candidaturas"

--- a/services/getJsonDoc.js
+++ b/services/getJsonDoc.js
@@ -10,6 +10,7 @@ export function getJsonDoc() {
   const files = fs.readdirSync(docsDirectory);
   const tags = [];
   let tagGroups = null;
+  let servers = null;
 
   files.forEach((file) => {
     if (file.split('.').pop() === 'json') {
@@ -32,6 +33,14 @@ export function getJsonDoc() {
       if (content['x-tagGroups']) {
         tagGroups = content['x-tagGroups'];
       }
+
+      // servers também é definido em um único arquivo (basic_info.json).
+      // O merge de arrays do lodash acontece por índice, então um arquivo que
+      // declarasse o próprio servers sobrescreveria a URL base da spec inteira
+      // (ex.: perder o prefixo /api e documentar URLs que retornam 404).
+      if (content.servers) {
+        servers = content.servers;
+      }
     }
   });
 
@@ -50,6 +59,10 @@ export function getJsonDoc() {
 
   if (tagGroups) {
     spec['x-tagGroups'] = tagGroups;
+  }
+
+  if (servers) {
+    spec.servers = servers;
   }
 
   return spec;

--- a/tests/docs-spec-refs.test.js
+++ b/tests/docs-spec-refs.test.js
@@ -20,4 +20,12 @@ describe('spec OpenAPI completa (docs)', () => {
     walk(spec);
     expect(broken).toEqual([]);
   });
+
+  it('servers da spec preserva o prefixo /api mesmo com docs que declaram servers', () => {
+    const spec = getJsonDoc();
+
+    expect(spec.servers).toBeDefined();
+    expect(spec.servers.length).toBeGreaterThan(0);
+    expect(spec.servers[0].url).toBe('https://brasilapi.com.br/api');
+  });
 });


### PR DESCRIPTION
Closes #903

## Problema

As URLs exibidas no Redoc (`/docs`) apareciam sem o prefixo `/api` — por exemplo `https://brasilapi.com.br/feriados/v1/{ano}` em vez de `https://brasilapi.com.br/api/feriados/v1/{ano}` — e retornavam 404 ao serem seguidas.

## Causa raiz

`services/getJsonDoc.js` monta a spec única concatenando todos os arquivos de `pages/docs/doc/*.json` com `lodash.merge`, que **combina arrays por índice**.

`basic_info.json` define a URL base correta:

```json
"servers": [{ "url": "https://brasilapi.com.br/api" }]
```

Só que `eleicoes.json` também declarava um `servers` próprio, sem o prefixo:

```json
"servers": [{ "url": "https://brasilapi.com.br" }]
```

Como `eleicoes.json` vem depois de `basic_info.json` na ordem alfabética do `readdirSync`, o merge por índice sobrescrevia `servers[0].url` e a spec inteira passava a apontar para `https://brasilapi.com.br`. O sintoma aparecia em **todos** os endpoints, não só em eleições.

## O que mudou

- **`pages/docs/doc/eleicoes.json`**: remove o bloco `servers` redundante. A URL base da spec é responsabilidade do `basic_info.json`. Isso também corrige as próprias rotas de eleições, que apontavam para `/eleicoes/...` quando as rotas reais são `/api/eleicoes/...`.
- **`services/getJsonDoc.js`**: extrai `servers` do merge, exatamente como já era feito com `tags` e `x-tagGroups` — os dois casos anteriores em que o merge de arrays do lodash causou problema. Sem isso, qualquer arquivo de doc que venha a declarar `servers` volta a quebrar a URL base de toda a documentação silenciosamente.
- **`tests/docs-spec-refs.test.js`**: teste cobrindo o caso, no arquivo que já testa a spec agregada.

## Como testei

Teste novo falhando antes da correção:

```
$ npm test -- tests/docs-spec-refs.test.js

 × spec OpenAPI completa (docs) > servers da spec preserva o prefixo /api ...
   → expected 'https://brasilapi.com.br' to be 'https://brasilapi.com.br/api'

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

Depois da correção:

```
$ npm test -- tests/docs-spec-refs.test.js

 ✓ tests/docs-spec-refs.test.js (2 tests) 1096ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Lint, mesmo comando do workflow `e2e-tests.yml`:

```
$ npx eslint pages/ services/ lib/ util/ middlewares/ errors/ --ext .js
(exit 0, sem erros)
```

Suíte completa:

```
$ npm test

 Test Files  1 failed | 51 passed | 7 skipped (59)
      Tests  2 failed | 462 passed | 77 skipped (541)
```

As 2 falhas são em `tests/diasuteis-v1.test.js` e **não têm relação com esta mudança** — reproduzi as mesmas duas falhas em `upstream/main` sem nenhuma alteração aplicada (`git stash` + `npm test -- tests/diasuteis-v1.test.js` → `2 failed | 6 passed`). Não mexi nelas para não misturar escopo.

## Impacto de compatibilidade

**Nenhum.** A mudança afeta apenas a documentação renderizada e o serviço que a agrega. Nenhum handler de `pages/api/**`, nenhum campo de resposta, nenhum status code e nenhuma URL de endpoint foram alterados. As URLs documentadas passam a coincidir com as rotas que já existiam.

---

Desenvolvido com assistência de LLM, revisado e testado por mim.
