### PR TITLE
fix(docs): restaura prefixo /api nas URLs da documentação OpenAPI

### DIFF
--- a/pages/docs/doc/cid10.json
+++ b/pages/docs/doc/cid10.json
@@ -1,5 +1,4 @@
 {
-  "openapi": "3.0.0",
   "paths": {
     "/oms/cid10/v1": {
       "get": {

--- a/pages/docs/doc/eleicoes.json
+++ b/pages/docs/doc/eleicoes.json
@@ -1,15 +1,4 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-        "title": "API de Eleições - BrasilAPI",
-        "version": "1.0.0",
-        "description": "Documentação dos endpoints de eleições integrados à API DivulgaCandContas do TSE."
-    },
-    "servers": [
-        {
-            "url": "https://brasilapi.com.br"
-        }
-    ],
     "tags": [
         {
             "name": "Candidaturas"

--- a/pages/docs/doc/status.json
+++ b/pages/docs/doc/status.json
@@ -1,5 +1,4 @@
 {
-  "openapi": "3.0.0",
   "paths": {
     "/status/v1": {
       "get": {

--- a/services/getJsonDoc.js
+++ b/services/getJsonDoc.js
@@ -4,6 +4,15 @@ import path from 'path';
 
 const docsDirectory = path.join(process.cwd(), 'pages/docs/doc');
 
+// Arquivo dono da identidade global da spec (openapi, info, servers).
+const BASE_FILE = 'basic_info.json';
+
+// Chaves globais que só podem vir do BASE_FILE. Um arquivo de endpoint que as
+// declare sobrescreve a spec inteira no merge do lodash — foi assim que o
+// `servers` perdeu o prefixo /api e todas as rotas da documentação passaram a
+// exibir URLs que retornam 404.
+const GLOBAL_KEYS = ['openapi', 'info', 'servers'];
+
 export function getJsonDoc() {
   let spec = {};
 
@@ -16,6 +25,11 @@ export function getJsonDoc() {
       const fullPath = path.join(docsDirectory, file);
 
       const content = JSON.parse(fs.readFileSync(fullPath, 'utf-8'));
+
+      if (file !== BASE_FILE) {
+        GLOBAL_KEYS.forEach((key) => delete content[key]);
+      }
+
       spec = merge(spec, content);
 
       // Seção de tags sendo tratada dentro de um foreach pois o merge dos

--- a/tests/docs-spec-refs.test.js
+++ b/tests/docs-spec-refs.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import { getJsonDoc } from '@/services/getJsonDoc';
 
 describe('spec OpenAPI completa (docs)', () => {
@@ -19,5 +21,42 @@ describe('spec OpenAPI completa (docs)', () => {
     };
     walk(spec);
     expect(broken).toEqual([]);
+  });
+
+  it('servers aponta para o host com prefixo /api', () => {
+    const spec = getJsonDoc();
+    expect(spec.servers).toEqual([{ url: 'https://brasilapi.com.br/api' }]);
+  });
+
+  it('identidade global vem do basic_info.json, não de arquivos de endpoint', () => {
+    const spec = getJsonDoc();
+    expect(spec.openapi).toBe('3.0.5');
+    expect(spec.info.title).toBe('Brasil API');
+  });
+
+  it('nenhum arquivo de endpoint declara chaves globais da spec', () => {
+    const docsDirectory = path.join(process.cwd(), 'pages/docs/doc');
+    const offenders = [];
+
+    fs.readdirSync(docsDirectory)
+      .filter((file) => file.endsWith('.json') && file !== 'basic_info.json')
+      .forEach((file) => {
+        const content = JSON.parse(
+          fs.readFileSync(path.join(docsDirectory, file), 'utf-8')
+        );
+        ['openapi', 'info', 'servers'].forEach((key) => {
+          if (key in content) offenders.push(`${file}: ${key}`);
+        });
+      });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('todos os paths documentados são relativos ao server (sem /api embutido)', () => {
+    const spec = getJsonDoc();
+    const withApiPrefix = Object.keys(spec.paths || {}).filter((p) =>
+      p.startsWith('/api/')
+    );
+    expect(withApiPrefix).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problema

Na documentação, ao expandir qualquer rota, a URL exibida vem sem o prefixo `/api`:

```
https://brasilapi.com.br/hospitais/v1     ← 404
https://brasilapi.com.br/api/hospitais/v1 ← correto
```

Quem copia a URL da documentação recebe 404. O problema afeta **todas** as rotas documentadas.

## Causa

`services/getJsonDoc.js` funde todos os JSONs de `pages/docs/doc/` com `lodash.merge`, em ordem alfabética de `readdirSync`. O `basic_info.json` é o dono da identidade global da spec e define corretamente:

```json
"servers": [{ "url": "https://brasilapi.com.br/api" }]
```

Só que o `eleicoes.json` também declarava chaves globais:

```json
"openapi": "3.0.0",
"info": { "title": "API de Eleições - BrasilAPI", ... },
"servers": [{ "url": "https://brasilapi.com.br" }]
```

Como `eleicoes` vem depois de `basic_info` no alfabeto, o `merge` sobrescreve `servers[0].url` e apaga o `/api` da spec inteira. Saída do merge antes da correção:

```
openapi : 3.0.0                          (esperado: 3.0.5)
title   : API de Eleições - BrasilAPI    (esperado: Brasil API)
servers : [{"url":"https://brasilapi.com.br"}]
```

O título e a descrição da home da documentação também estavam sendo sequestrados — não era só o `/api`.

Introduzido em dfa9354 (#874).

## Solução

- Remove `openapi`/`info`/`servers` do `eleicoes.json`. Seus `paths` já seguem a convenção do projeto (`/eleicoes/...`, relativos ao server), então nada muda para essas rotas além de voltarem a ganhar o prefixo correto.
- Remove `openapi` de `cid10.json` e `status.json`, que causavam o mesmo clobbering na versão da spec.
- `getJsonDoc` passa a ignorar essas chaves globais em qualquer arquivo que não seja o `basic_info.json`, para que um arquivo de endpoint não volte a derrubar a spec inteira em silêncio.
- Testes de regressão cobrindo `servers`, identidade global, ausência de chaves globais nos arquivos de endpoint e o formato dos paths documentados.

Nenhum endpoint, campo de resposta ou status HTTP foi alterado — a mudança é restrita à montagem da documentação.

## Verificação

- `npx vitest run tests/docs-spec-refs.test.js` — 5/5 passando
- `npx eslint pages/ services/ lib/ util/ middlewares/ errors/ --ext .js` — limpo
- Documentação renderizada localmente: o campo da rota expandida passa a exibir `https://brasilapi.com.br/api/cnpj/v1/{cnpj}`, e o cabeçalho volta a "Brasil API (1.0.0)" com a descrição original
- Smoke local: `/api/hospitais/v1` → 200, `/hospitais/v1` → 404
