### PR TITLE
fix(ci): workflow de hospitais abre PR em vez de push na main protegida

### DIFF
--- a/.github/workflows/hospitais-snapshot.yml
+++ b/.github/workflows/hospitais-snapshot.yml
@@ -87,7 +87,9 @@ jobs:
       - name: Abrir PR com snapshot atualizado
         if: steps.preparar.outputs.houve_mudanca == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        # Preso ao SHA completo (v6.1.0) em vez da tag: uma tag e mutavel e pode
+        # ser reapontada para outro commit, o SHA nao.
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(hospitais): atualiza snapshot diario do MapaSUS'

--- a/.github/workflows/hospitais-snapshot.yml
+++ b/.github/workflows/hospitais-snapshot.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   hospitais-snapshot:
@@ -20,6 +21,8 @@ jobs:
     steps:
       - name: Puxar o codigo do commit
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Instalar Node.js
         uses: actions/setup-node@v4
@@ -49,18 +52,51 @@ jobs:
           path: services/hospitais/snapshots/metrics-latest.json
           if-no-files-found: error
 
-      - name: Commitar snapshot atualizado
+      # A branch main tem protecao (GH006: Protected branch update failed),
+      # entao o push direto falha — abrimos um PR com o snapshot atualizado.
+      #
+      # O latest.json carrega generated_at, que muda a cada execucao. Comparar
+      # o arquivo inteiro abriria um PR diario mesmo sem mudanca de dados, entao
+      # o guard olha so o payload (hospitais + ciatox).
+      #
+      # O sort_by(.id) canonicaliza a ordem: hospitais ja sai ordenado do script,
+      # mas ciatox vem na ordem que o MapaSUS devolver.
+      - name: Preparar mudancas do snapshot
+        id: preparar
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add services/hospitais/snapshots/latest.json
-          git add services/hospitais/snapshots/metrics-latest.json
+          canonico='{hospitais: (.hospitais | sort_by(.id)), ciatox: (.ciatox | sort_by(.id))}'
 
-          if git diff --staged --quiet; then
-            echo "Sem alteracoes de snapshot para commit"
+          anterior=$(git show HEAD:services/hospitais/snapshots/latest.json \
+            | jq -S "$canonico")
+          atual=$(jq -S "$canonico" services/hospitais/snapshots/latest.json)
+
+          if [ "$anterior" = "$atual" ]; then
+            echo "Dados de hospitais sem alteracoes, nada para commitar"
+            echo "houve_mudanca=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git commit -m "chore(hospitais): atualiza snapshot diario do MapaSUS"
-          git push
+          echo "houve_mudanca=true" >> "$GITHUB_OUTPUT"
+
+          git add services/hospitais/snapshots/latest.json
+          git add services/hospitais/snapshots/metrics-latest.json
+
+      - name: Abrir PR com snapshot atualizado
+        if: steps.preparar.outputs.houve_mudanca == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(hospitais): atualiza snapshot diario do MapaSUS'
+          branch: chore/hospitais-snapshot-update
+          delete-branch: true
+          title: 'chore(hospitais): atualiza snapshot diario do MapaSUS'
+          body: |
+            Atualização automática do snapshot diário de hospitais de referência
+            (workflow `Snapshot Hospitais de Referencia`, fonte MapaSUS).
+
+            Quando os dados não mudam, nenhum PR é aberto.
+          labels: automated


### PR DESCRIPTION
## Problema

O workflow `Snapshot Hospitais de Referencia` falha em **todas** as execuções desde pelo menos 03/09:

```
! [remote rejected] main -> main (protected branch hook declined)
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

Últimas 8 execuções, todas `failure` ([run mais recente](https://github.com/BrasilAPI/BrasilAPI/actions/runs/34449420861)).

Consequência: o snapshot em `services/hospitais/snapshots/latest.json` está congelado em **12/08/2026** (`generated_at` do `metrics-latest.json`), apesar do cron ser diário. O `/api/hospitais/v1` serve dados de agosto.

## Causa

O #896 migrou os workflows de banks e de pix para `peter-evans/create-pull-request`, justamente porque a `main` é protegida e o push direto é rejeitado com GH006. O #891 (hospitais) mergeou **depois** e carregou o padrão antigo de `git commit && git push`. Os três workflows ficaram fora de sincronia:

| Workflow | Estratégia | Situação |
|---|---|---|
| `pix-participants-snapshot.yml` | create-pull-request | ✅ success |
| `banks-headquarters-snapshot.yml` | create-pull-request | ✅ abre PR (#902) |
| `hospitais-snapshot.yml` | `git push` direto | ❌ falha diária |

## O que mudou

- Alinha o workflow ao padrão dos outros dois: `peter-evans/create-pull-request@v6` na branch `chore/hospitais-snapshot-update`, com `pull-requests: write` nas permissions e `fetch-depth: 0` no checkout.
- **Guard de payload.** O `latest.json` de hospitais carrega um `generated_at` no topo, que muda a cada execução. Comparar o arquivo inteiro abriria um PR **todo dia** mesmo sem mudança de dados, então o guard compara via `jq` apenas `hospitais` + `ciatox`.
- **Ordem canônica.** O array `hospitais` já sai ordenado do script (`sort_by(a.id - b.id)`), mas `ciatox` vem direto de `ciatoxResponse.centers`, na ordem que o MapaSUS devolver. O `sort_by(.id)` no guard evita PR espúrio por reordenação — os 32 registros de ciatox têm `id` único.
- O passo do PR fica condicionado a `steps.preparar.outputs.houve_mudanca`, porque `exit 0` dentro de um passo `run` encerra só aquele passo — os seguintes continuam rodando.

Nenhuma mudança em handler, serviço, dado ou endpoint. É só a etapa de publicação do workflow.

## Como testei

YAML e sintaxe do shell validados (`yaml.safe_load`, `bash -n` sobre o bloco `run` extraído do YAML).

Guard exercitado contra o `latest.json` real do repositório, nos dois sentidos:

| Cenário | Esperado | Obtido |
|---|---|---|
| sem mudança nenhuma | não abre PR | não abre |
| só `generated_at` mudou | não abre PR | não abre |
| `ciatox` reordenado, mesmo dado | não abre PR | não abre |
| hospital removido | abre PR | abre |
| telefone de ciatox mudou | abre PR | abre |
| nome de hospital mudou | abre PR | abre |

A validação de ponta a ponta só é possível após o merge, já que o `create-pull-request` precisa rodar com o `GITHUB_TOKEN` do repositório. Sugiro disparar o `workflow_dispatch` logo depois para confirmar — deve abrir um PR com o snapshot atualizado, cobrindo o intervalo desde 12/08.